### PR TITLE
Support access branches

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -3,9 +3,9 @@
   :resource-paths #{"src"}
   :dependencies '[
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
+    [org.clojure/clojure "1.9.0-alpha15" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
-    [org.clojure/core.async "0.3.441"]
+    [org.clojure/core.async "0.3.442"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha4"]
     ;; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.5.2-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.5.3-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.2-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.3-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.1-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.2-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.8-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.9-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.4.0-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.4.1-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.4.1-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.5.0-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.11-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.12-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,7 @@
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
     [liberator "0.14.1"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
-    [amazonica "0.3.88"]
+    [amazonica "0.3.90"]
     ;; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [clj-jwt "0.1.1"]
     ;; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
@@ -31,10 +31,12 @@
     ;; Date and time lib https://github.com/clj-time/clj-time
     [clj-time "0.13.0"]
     ;; Async programming tools https://github.com/ztellman/manifold
-    [manifold "0.1.6-alpha6"]
-    ; Data validation https://github.com/Prismatic/schema
+    [manifold "0.1.6"]
+    ;; Data validation https://github.com/Prismatic/schema
     [prismatic/schema "1.1.3"]
-
+    ;; Environment settings from different sources https://github.com/weavejester/environ
+    [environ "1.1.0"]
+    
     ;; Boot tasks ==========================================
     ;; Example-based testing https://github.com/marick/Midje
     [midje "1.9.0-alpha6" :scope "test"]
@@ -49,7 +51,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.13-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.14-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -51,7 +51,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.14-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.15-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.5-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.6-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -51,7 +51,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.16-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.17-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -51,7 +51,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.15-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.16-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.6-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.7-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.5.0-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.5.1-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.7-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.8-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.12-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.13-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.3.0-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.4.0-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.10-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.11-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -14,6 +14,8 @@
     [com.taoensso/timbre "4.8.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [raven-clj "1.5.0"]
+    ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
+    [liberator "0.14.1"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
     [amazonica "0.3.85"]
     ;; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
@@ -45,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.2.4-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.3.0-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
-    [org.clojure/core.async "0.2.395"]
+    [org.clojure/core.async "0.3.441"]
     ; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha4"]
     ;; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
@@ -15,13 +15,13 @@
     ; Component Lifecycle https://github.com/stuartsierra/component
     [com.stuartsierra/component "0.3.2"] 
     ;; Pure Clojure/Script logging library https://github.com/ptaoussanis/timbre
-    [com.taoensso/timbre "4.8.0"]
+    [com.taoensso/timbre "4.9.0-alpha1"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [raven-clj "1.5.0"]
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
     [liberator "0.14.1"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
-    [amazonica "0.3.86"]
+    [amazonica "0.3.88"]
     ;; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [clj-jwt "0.1.1"]
     ;; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
@@ -31,7 +31,7 @@
     ;; Date and time lib https://github.com/clj-time/clj-time
     [clj-time "0.13.0"]
     ;; Async programming tools https://github.com/ztellman/manifold
-    [manifold "0.1.6-alpha4"]
+    [manifold "0.1.6-alpha6"]
     ; Data validation https://github.com/Prismatic/schema
     [prismatic/schema "1.1.3"]
 
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.9-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.10-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.3-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.4-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -45,7 +45,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.2.3-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.2.4-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.4-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.5-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -6,11 +6,11 @@
     [org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.3.441"]
-    ; Erlang-esque pattern matching https://github.com/clojure/core.match
+    ;; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha4"]
     ;; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     [defun "0.3.0-RC1"]
-    ; More than one binding for if/when macros https://github.com/LockedOn/if-let
+    ;; More than one binding for if/when macros https://github.com/LockedOn/if-let
     [lockedon/if-let "0.1.0"]
     ; Component Lifecycle https://github.com/stuartsierra/component
     [com.stuartsierra/component "0.3.2"] 

--- a/build.boot
+++ b/build.boot
@@ -49,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.0-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.1-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -47,7 +47,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.5.1-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.5.2-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/build.boot
+++ b/build.boot
@@ -6,8 +6,12 @@
     [org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.2.395"]
+    ; Erlang-esque pattern matching https://github.com/clojure/core.match
+    [org.clojure/core.match "0.3.0-alpha4"]
     ;; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     [defun "0.3.0-RC1"]
+    ; More than one binding for if/when macros https://github.com/LockedOn/if-let
+    [lockedon/if-let "0.1.0"]
     ; Component Lifecycle https://github.com/stuartsierra/component
     [com.stuartsierra/component "0.3.2"] 
     ;; Pure Clojure/Script logging library https://github.com/ptaoussanis/timbre
@@ -17,7 +21,7 @@
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
     [liberator "0.14.1"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
-    [amazonica "0.3.85"]
+    [amazonica "0.3.86"]
     ;; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [clj-jwt "0.1.1"]
     ;; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
@@ -30,8 +34,6 @@
     [manifold "0.1.6-alpha4"]
     ; Data validation https://github.com/Prismatic/schema
     [prismatic/schema "1.1.3"]
-    ; More than one binding for if/when macros https://github.com/LockedOn/if-let
-    [lockedon/if-let "0.1.0"]
 
     ;; Boot tasks ==========================================
     ;; Example-based testing https://github.com/marick/Midje
@@ -47,7 +49,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.5.3-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.6.0-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -97,14 +97,6 @@
       :body reason
       :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
 
-(defun only-accept
-  ([status media-types :guard sequential?] (only-accept status (s/join "," media-types)))
-  ([status media-types :guard string?]
-  (ring-response
-    {:status status
-     :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-types UTF8)
-     :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}})))
-
 (defn location-response 
   ([location body media-type] (location-response location body 201 media-type))
   ([location body status media-type]
@@ -115,6 +107,19 @@
                "Content-Type" (format "%s;charset=%s" media-type UTF8)}})))
 
 ;; ----- Validations -----
+
+(defun only-accept
+  ([status media-types :guard sequential?] (only-accept status (s/join "," media-types)))
+  ([status media-types :guard string?]
+  (ring-response
+    {:status status
+     :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-types UTF8)
+     :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}})))
+
+(defun available-media-types
+  ([] (available-media-types []))
+  ([media-type :guard string?] (available-media-types [media-type]))
+  ([media-types :guard sequential?] (conj media-types "*/*")))
 
 (defn malformed-json?
   "Read in the body param from the request as a string, parse it into JSON, make sure all the

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -160,7 +160,7 @@
   "Read supplied JWToken from the request headers.
 
    If a valid token is supplied return a map containing :jwtoken and associated :user.
-   If invalid token is supplied return {:jwtoken false}.
+   If invalid token is supplied return nil.
    If no Authorization headers are supplied return nil."
   [headers passphrase]
   (let [token (get-token headers)]

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -116,11 +116,6 @@
      :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-types UTF8)
      :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}})))
 
-(defun available-media-types
-  ([] (available-media-types []))
-  ([media-type :guard string?] (available-media-types [media-type]))
-  ([media-types :guard sequential?] (conj media-types "*/*")))
-
 (defn malformed-json?
   "Read in the body param from the request as a string, parse it into JSON, make sure all the
   keys are keywords, and then return it, mapped to :data as the 2nd value in a vector,

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -1,0 +1,210 @@
+(ns oc.lib.api.common
+  (:require [clojure.string :as s]
+            [defun.core :refer (defun)]
+            [taoensso.timbre :refer (debug info warn error fatal spy)]
+            [cheshire.core :as json]
+            [liberator.representation :refer (ring-response)]
+            [liberator.core :refer (by-method)]
+            [oc.lib.jwt :as jwt]))
+
+(def UTF8 "utf-8")
+
+(def malformed true)
+(def good-json false)
+
+(def json-mime-type "application/json")
+(def text-mime-type "text/plain")
+
+;; ----- Responses -----
+
+(defn text-response
+  "Helper to format a text ring response"
+  ([body status] (text-response body status {}))
+  
+  ([body status headers]
+  {:pre [(string? body)
+         (integer? status)
+         (map? headers)]}
+  (ring-response {
+    :body body 
+    :status status 
+    :headers (merge {"Content-Type" text-mime-type} headers)})))
+
+(defun json-response
+  "Helper to format a generic JSON body ring response"
+  ([body status] (json-response body status json-mime-type {}))
+  
+  ([body status headers :guard map?] (json-response body status json-mime-type headers))
+
+  ([body status mime-type :guard string?] (json-response body status mime-type {}))
+
+  ([body :guard #(or (map? %) (sequential? %)) status mime-type headers]
+  (json-response (json/generate-string body {:pretty true}) status mime-type headers))
+  
+  ([body :guard string? status :guard integer? mime-type :guard string? headers :guard map?]
+  (ring-response {:body body
+                  :status status 
+                  :headers (merge {"Content-Type" mime-type} headers)})))
+
+(defn error-response
+  "Helper to format a JSON ring response with an error."
+  ([error status] (error-response error status {}))
+  
+  ([error status headers]
+  {:pre [(integer? status)
+         (map? headers)]}
+  (ring-response {
+    :body error
+    :status status
+    :headers headers})))
+
+(defn blank-response [] (ring-response {:status 204}))
+
+(defn options-response [methods]
+  (ring-response {
+    :status 204
+    :headers {"Allow" (s/join ", " (map s/upper-case (map name methods)))}}))
+
+(defn missing-response
+  ([]
+  (ring-response {
+    :status 404
+    :body ""
+    :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
+  ([reason]
+  (ring-response {
+    :status 404
+    :body reason
+    :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}})))
+
+(def unauthorized "Not authorized. Provide a Bearer JWToken in the Authorization header.")
+(defn unauthorized-response []
+  (ring-response {
+    :status 401
+    :body unauthorized
+    :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
+
+(def forbidden "Forbidden. Provide a Bearer JWToken in the Authorization header that is allowed to do this operation.")
+(defn forbidden-response []
+  (ring-response {
+    :status 403
+    :body forbidden
+    :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
+
+(defn unprocessable-entity-response [reason]
+  (ring-response
+    {:status 422
+      :body reason
+      :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
+
+(defn only-accept [status media-type]
+  (ring-response
+    {:status status
+     :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-type UTF8)
+     :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
+
+(defn location-response [path-parts body media-type]
+  (ring-response
+    {:body body
+     :headers {"Location" (format "/%s" (s/join "/" path-parts))
+               "Content-Type" (format "%s;charset=%s" media-type UTF8)}}))
+
+;; ----- Validations -----
+
+(defn malformed-json?
+  "Read in the body param from the request as a string, parse it into JSON, make sure all the
+  keys are keywords, and then return it, mapped to :data as the 2nd value in a vector,
+  with the first value indicating it's not malformed. Otherwise just indicate it's malformed."
+  ([ctx] (malformed-json? ctx false))
+  ([ctx allow-nil?]
+  (try
+    (if-let [data (-> (get-in ctx [:request :body]) slurp (json/parse-string true))]
+      ; handle case of a string which is valid JSON, but still malformed for us (since it's not a map)
+      (do (when-not (map? data) (throw (Exception.)))
+        [good-json {:data data}]))
+    (catch Exception e
+      (if allow-nil?
+        [good-json {:data {}}]
+        (do (warn "Request body not processable as JSON: " e)
+          [malformed]))))))
+
+(defn known-content-type?
+  [ctx content-type]
+  (if-let [request-type (get-in ctx [:request :headers "content-type"])]
+    (= (first (s/split content-type #";")) (first (s/split request-type #";")))
+    true))
+
+;; ----- Authentication and Authorization -----
+
+(defn authenticated?
+  "Return true if the request contains a valid JWToken"
+  [ctx]
+  (and (:jwtoken ctx) (:user ctx)))
+
+(defn- read-token
+  "Read supplied JWToken from the request headers.
+
+   If a valid token is supplied return a map containing :jwtoken and associated :user.
+   If invalid token is supplied return {:jwtoken false}.
+   If no Authorization headers are supplied return nil."
+  [headers passphrase]
+  (if-let [authorization (or (get headers "Authorization") (get headers "authorization"))]
+    (let [jwtoken (last (s/split authorization #" "))]
+      (if (jwt/valid? jwtoken passphrase)
+        {:jwtoken jwtoken
+         :user (:claims (jwt/decode jwtoken))}
+        {:jwtoken false}))))
+
+(defn allow-anonymous
+  "Allow unless there is a JWToken provided and it's invalid."
+  [ctx]
+  (boolean (or (nil? (:jwtoken ctx)) (:jwtoken ctx))))
+
+(defn allow-authenticated
+  "Allow only if a valid JWToken is provided."
+  [ctx]
+  (authenticated? ctx))
+
+;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
+
+;; verify validity of JWToken if it's provided, but it's not required
+(defn anonymous-resource [passphrase] {
+  :initialize-context (fn [ctx] (read-token (get-in ctx [:request :headers]) passphrase))
+  :authorized? allow-anonymous
+  :handle-unauthorized (fn [_] (unauthorized-response))
+  :handle-forbidden  (fn [ctx] (if (:jwtoken ctx) (forbidden-response) (unauthorized-response)))})
+
+;; verify validity and presence of required JWToken
+(defn authenticated-resource [passphrase] {
+  :initialize-context (fn [ctx] (read-token (get-in ctx [:request :headers]) passphrase))
+  :authorized? (fn [ctx] (authenticated? ctx))
+  :handle-not-found (fn [_] (missing-response))
+  :handle-unauthorized (fn [_] (unauthorized-response))
+  :handle-forbidden (fn [_] (forbidden-response))})
+
+(def open-company-resource {
+  :available-charsets [UTF8]
+  :handle-not-found (fn [_] (missing-response))
+  :handle-not-implemented (fn [_] (missing-response))
+  :allowed-methods [:options :get :put :patch :delete]
+  :respond-with-entity? (by-method {
+    :options false
+    :get true
+    :put true
+    :patch true
+    :delete false})
+  :malformed? (by-method {
+    :options false
+    :get false
+    :delete false
+    :post (fn [ctx] (malformed-json? ctx))
+    :put (fn [ctx] (malformed-json? ctx))
+    :patch (fn [ctx] (malformed-json? ctx))})
+  :can-put-to-missing? (fn [_] false)
+  :conflict? (fn [_] false)})
+
+(defn open-company-anonymous-resource [passphrase]
+  (merge open-company-resource (anonymous-resource passphrase)))
+
+(defn open-company-authenticated-resource [passphrase]
+  (merge open-company-resource (authenticated-resource passphrase)))

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -97,11 +97,13 @@
       :body reason
       :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
 
-(defn only-accept [status media-type]
+(defun only-accept
+  ([status media-types :guard sequential?] (only-accept status (s/join "," media-types)))
+  ([status media-types :guard string?]
   (ring-response
     {:status status
-     :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-type UTF8)
-     :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}}))
+     :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-types UTF8)
+     :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}})))
 
 (defn location-response [path-parts body media-type]
   (ring-response

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -105,11 +105,14 @@
      :body (format "Acceptable media type: %s\nAcceptable charset: %s" media-types UTF8)
      :headers {"Content-Type" (format "text/plain;charset=%s" UTF8)}})))
 
-(defn location-response [path-parts body media-type]
+(defn location-response 
+  ([location body media-type] (location-response location body 201 media-type))
+  ([location body status media-type]
   (ring-response
     {:body body
-     :headers {"Location" (format "/%s" (s/join "/" path-parts))
-               "Content-Type" (format "%s;charset=%s" media-type UTF8)}}))
+     :status status
+     :headers {"Location" location
+               "Content-Type" (format "%s;charset=%s" media-type UTF8)}})))
 
 ;; ----- Validations -----
 

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -161,10 +161,9 @@
    If no Authorization headers are supplied return nil."
   [headers passphrase]
   (let [token (get-token headers)]
-    (if (jwt/valid? token passphrase)
+    (when (jwt/valid? token passphrase)
       {:jwtoken token
-       :user (:claims (jwt/decode token))}
-      {:jwtoken false})))
+       :user (:claims (jwt/decode token))})))
 
 (defn allow-anonymous
   "Allow unless there is a JWToken provided and it's invalid."

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -144,7 +144,9 @@
 (defn authenticated?
   "Return true if the request contains a valid JWToken"
   [ctx]
-  (and (:jwtoken ctx) (:user ctx)))
+  (if (= (-> ctx :request :request-method) :options)
+    true ; always allow options
+    (and (:jwtoken ctx) (:user ctx))))
 
 (defn get-token
   "
@@ -172,12 +174,16 @@
 (defn allow-anonymous
   "Allow unless there is a JWToken provided and it's invalid."
   [ctx]
-  (boolean (or (nil? (:jwtoken ctx)) (:jwtoken ctx))))
+  (if (= (-> ctx :request :request-method)) :options)
+    true ; allows allow options
+    (boolean (or (nil? (:jwtoken ctx)) (:jwtoken ctx))))
 
 (defn allow-authenticated
   "Allow only if a valid JWToken is provided."
   [ctx]
-  (authenticated? ctx))
+  (if (= (-> ctx :request :request-method) :options)
+    true ; always allow options
+    (authenticated? ctx)))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -160,13 +160,14 @@
   "Read supplied JWToken from the request headers.
 
    If a valid token is supplied return a map containing :jwtoken and associated :user.
-   If invalid token is supplied return nil.
+   If invalid token is supplied return a map containing :jwtoken and false.
    If no Authorization headers are supplied return nil."
   [headers passphrase]
-  (let [token (get-token headers)]
-    (when (jwt/valid? token passphrase)
+  (when-let [token (get-token headers)]
+    (if (jwt/valid? token passphrase)
       {:jwtoken token
-       :user (:claims (jwt/decode token))})))
+       :user (:claims (jwt/decode token))}
+      {:jwtoken false})))
 
 (defn allow-anonymous
   "Allow unless there is a JWToken provided and it's invalid."

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -5,7 +5,8 @@
             [if-let.core :refer (if-let*)]
             [clj-time.format :as format]
             [clj-time.core :as time]
-            [rethinkdb.query :as r]))
+            [rethinkdb.query :as r]
+            [oc.lib.schema :as lib-schema]))
 
 ;; ----- ISO 8601 timestamp -----
 
@@ -21,13 +22,7 @@
 (defn conn?
   "Check if a var is a valid RethinkDB connection map/atom."
   [conn]
-  (if (and 
-        (map? conn)
-        (:client @conn)
-        (:db @conn)
-        (:token @conn))
-    true
-    false))
+  (lib-schema/conn? conn))
 
 (defn updated-at-order
   "Return items in a sequence sorted by their :updated-at key. Newest first."

--- a/src/oc/lib/db/migrations.clj
+++ b/src/oc/lib/db/migrations.clj
@@ -1,5 +1,5 @@
 ;; Very loosely patterned after https://github.com/yogthos/migratus
-(ns oc.lib.rethinkdb.migrations
+(ns oc.lib.db.migrations
   "Migrate RethinkDB data."
   (:require [clojure.string :as s]
             [clj-time.core :as t]

--- a/src/oc/lib/db/pool.clj
+++ b/src/oc/lib/db/pool.clj
@@ -1,4 +1,4 @@
-(ns oc.lib.rethinkdb.pool
+(ns oc.lib.db.pool
   "RethinkDB database connection pool."
   (:require [rethinkdb.query :as r]
             [taoensso.timbre :as timbre])

--- a/src/oc/lib/hateoas.clj
+++ b/src/oc/lib/hateoas.clj
@@ -121,3 +121,10 @@
   (delete-link url {}))
   ([url others]
   (link-map "delete" DELETE url {} others)))
+
+(defn archive-link
+  "Link to archive an existing resource."
+  ([url]
+  (archive-link url {}))
+  ([url others]
+  (link-map "archive" DELETE url {} others)))

--- a/src/oc/lib/hateoas.clj
+++ b/src/oc/lib/hateoas.clj
@@ -59,6 +59,8 @@
 
 (defn remove-link
   "Link to remove an item from a collection."
+  ([url]
+  (link-map "remove" DELETE url nil))
   ([url media-type]
   (link-map "remove" DELETE url media-type))
   ([url media-type & others]

--- a/src/oc/lib/hateoas.clj
+++ b/src/oc/lib/hateoas.clj
@@ -24,13 +24,13 @@
 
   Any additional key/values will be included as additional properties of the link.
   "
-  [rel method url media-types & others]
+  [rel method url media-types others]
   {:pre [(string? rel)
          (http-methods method)
          (string? url)
-         (media-types? media-types)]}
-  (let [link-map (apply array-map (flatten (into
-                    [:rel rel :method method :href url] others)))
+         (media-types? media-types)
+         (map? others)]}
+  (let [link-map (merge {:rel rel :method method :href url} others)
         accept (:accept media-types)
         accept-link-map (if accept (assoc link-map :accept accept) link-map)
         content-type (:content-type media-types)]
@@ -41,73 +41,81 @@
 (defn self-link 
   "Link that points back to the resource itself."
   ([url media-type]
-  (link-map "self" GET url media-type))
-  ([url media-type & others]
+  (self-link url media-type {}))
+  
+  ([url media-type others]
   (link-map "self" GET url media-type others)))
 
 (defn collection-link
   "Link that points to a collection (list) of items."
   ([url media-type]
-  (link-map "collection" GET url media-type))
-  ([url media-type & others]
+  (collection-link url media-type {}))
+  
+  ([url media-type others]
   (link-map "collection" GET url media-type others)))
 
 (defn item-link
   "Link that points to an individual item in a collection."
   ([url media-type]
-  (link-map "item" GET url media-type))
-  ([url media-type & others]
+  (item-link url media-type {}))
+  
+  ([url media-type others]
   (link-map "item" GET url media-type)))
 
 (defn up-link 
   "Link that points to the parent collection that contains this item."
   ([url media-type]
-  (link-map "up" GET url media-type))
-  ([url media-type & others]
+  (up-link url media-type {}))
+  
+  ([url media-type others]
   (link-map "up" GET url media-type others)))
 
 (defn add-link
   "Link to add an existing item to a collection."
   ([method url media-type]
-  (link-map "add" method url media-type))
-  ([method url media-type & others]
+  (add-link method url media-type {}))
+  
+  ([method url media-type others]
   (link-map "add" method url media-type others)))
 
 (defn remove-link
   "Link to remove an item from a collection."
   ([url]
-  (link-map "remove" DELETE url nil))
+  (remove-link url {} {}))
+  
   ([url media-type]
-  (link-map "remove" DELETE url media-type))
-  ([url media-type & others]
+  (remove-link url media-type {}))
+  
+  ([url media-type others]
   (link-map "remove" DELETE url media-type others)))
 
 (defn create-link 
   "Link to create a new resource."
   ([url media-type]
-  (link-map "create" POST url media-type))
-  ([url media-type & others]
+  (create-link url media-type {}))
+
+  ([url media-type others]
   (link-map "create" POST url media-type others)))
 
 (defn update-link
   "Link to replace an existing resource with new content."
   ([url media-types]
-  (link-map "update" PUT url media-types))
+  (update-link url media-types {}))
 
-  ([url media-types & others]
+  ([url media-types others]
   (link-map "update" PUT url media-types others)))
 
 (defn partial-update-link
   "Link to update an existing resource with a fragment of content that's merged into the existing content."
   ([url media-types]
-  (link-map "partial-update" PATCH url media-types))
+  (partial-update-link url media-types {}))
   
-  ([url media-types & others]
+  ([url media-types others]
   (link-map "partial-update" PATCH url media-types others)))
 
 (defn delete-link
   "Link to delete an existing resource."
   ([url]
-  (link-map "delete" DELETE url {}))
-  ([url & others]
+  (delete-link url {}))
+  ([url others]
   (link-map "delete" DELETE url {} others)))

--- a/src/oc/lib/hateoas.clj
+++ b/src/oc/lib/hateoas.clj
@@ -24,7 +24,9 @@
 
   Any additional key/values will be included as additional properties of the link.
   "
-  [rel method url media-types others]
+  ([rel method url media-types] (link-map rel method url media-types {}))
+  
+  ([rel method url media-types others]
   {:pre [(string? rel)
          (http-methods method)
          (string? url)
@@ -36,7 +38,7 @@
         content-type (:content-type media-types)]
     (if content-type
       (assoc accept-link-map :content-type content-type)
-      accept-link-map)))
+      accept-link-map))))
 
 (defn self-link 
   "Link that points back to the resource itself."

--- a/src/oc/lib/hateoas.clj
+++ b/src/oc/lib/hateoas.clj
@@ -105,6 +105,9 @@
   ([url media-types & others]
   (link-map "partial-update" PATCH url media-types others)))
 
-(defn delete-link [url]
+(defn delete-link
   "Link to delete an existing resource."
-  (array-map :rel "delete" :method DELETE :href url))
+  ([url]
+  (link-map "delete" DELETE url {}))
+  ([url & others]
+  (link-map "delete" DELETE url {} others)))

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -10,7 +10,7 @@
 
 (def media-type "application/jwt")
 
-(def SlackBots {lib-schema/UniqueID [{:id schema/Str :token schema/Str :slack-org schema/Str}]})
+(def SlackBots {lib-schema/UniqueID [{:id schema/Str :token schema/Str :slack-org-id schema/Str}]})
 
 (def auth-sources #{:email :slack})
 

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -10,7 +10,7 @@
 
 (def media-type "application/jwt")
 
-(def SlackBots {lib-schema/UniqueID {:id schema/Str :token schema/Str}})
+(def SlackBots {lib-schema/UniqueID {:id schema/Str :token schema/Str :slack-org schema/Str}})
 
 (def auth-sources #{:email :slack})
 

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -67,13 +67,6 @@
   [token]
   (jwt/str->jwt token))
 
-(defn read-token
-  "Read a JWToken from the HTTP Authorization header"
-  [headers]
-  (when-let* [auth-header (or (get headers "authorization") (get headers "Authorization"))
-              jwt         (last (string/split auth-header #" "))]
-    (when (check-token jwt) jwt)))
-
 (defn valid?
   [token passphrase]
   (try

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -27,6 +27,7 @@
   (schema/optional-key :slack-id) schema/Str
   (schema/optional-key :slack-token) schema/Str
   (schema/optional-key :slack-bots) SlackBots
+  :refresh-url lib-schema/NonBlankStr
   :expire schema/Num})
 
 (defn expired?

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -39,7 +39,7 @@
 
 (defn expire [payload]
   "Set an expire property in the JWToken payload, longer if there's a bot, shorter if not."
-  (let [expire-by (-> (if (:bot payload) 24 2)
+  (let [expire-by (-> (if (empty? (:slack-bots payload)) 2 24)
                       t/hours t/from-now .getMillis)]
     (assoc payload :expire expire-by)))
 

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -10,7 +10,7 @@
 
 (def media-type "application/jwt")
 
-(def SlackBots {lib-schema/UniqueID {:id schema/Str :token schema/Str :slack-org schema/Str}})
+(def SlackBots {lib-schema/UniqueID [{:id schema/Str :token schema/Str :slack-org schema/Str}]})
 
 (def auth-sources #{:email :slack})
 

--- a/src/oc/lib/rethinkdb/common.clj
+++ b/src/oc/lib/rethinkdb/common.clj
@@ -109,10 +109,7 @@
   {:pre [(conn? conn)
          (string? table-name)
          (or (keyword? index-name) (string? index-name))
-         (or (string? index-value) (sequential? index-value))
-         (if (sequential? index-value)
-            (every? #(or (keyword? %) (string? %)) index-value)
-            true)]}
+         (or (string? index-value) (sequential? index-value))]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
     (with-timeout default-timeout
        (-> (r/table table-name)
@@ -124,9 +121,6 @@
          (string? table-name)
          (or (keyword? index-name) (string? index-name))
          (or (string? index-value) (sequential? index-value))
-         (if (sequential? index-value)
-            (every? #(or (keyword? %) (string? %)) index-value)
-            true)         
          (sequential? fields)
          (every? #(or (keyword? %) (string? %)) fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]

--- a/src/oc/lib/schema.clj
+++ b/src/oc/lib/schema.clj
@@ -48,6 +48,17 @@
   (and (string? password)
        (>= (count password) 5)))
 
+(defn conn?
+  "Check if a var is a valid RethinkDB connection map/atom."
+  [conn]
+  (if (and 
+        (map? conn)
+        (:client @conn)
+        (:db @conn)
+        (:token @conn))
+    true
+    false))
+
 ;; ----- Schema -----
 
 (def NonBlankStr (schema/pred #(and (string? %) (not (s/blank? %)))))
@@ -62,3 +73,5 @@
 (def EmailAddress (schema/pred valid-email-address?))
 
 (def EmailDomain (schema/pred valid-email-domain?))
+
+(def Conn (schema/pred #(conn? %)))

--- a/src/oc/lib/schema.clj
+++ b/src/oc/lib/schema.clj
@@ -51,13 +51,16 @@
 (defn conn?
   "Check if a var is a valid RethinkDB connection map/atom."
   [conn]
-  (if (and 
-        (map? conn)
-        (:client @conn)
-        (:db @conn)
-        (:token @conn))
-    true
-    false))
+  (try
+    (if (and 
+          (map? conn)
+          (:client @conn)
+          (:db @conn)
+          (:token @conn))
+      true
+      false)
+    (catch Exception e
+      false)))
 
 ;; ----- Schema -----
 

--- a/test/oc/unit/db/pool.clj
+++ b/test/oc/unit/db/pool.clj
@@ -1,6 +1,6 @@
-(ns oc.unit.rethinkdb.pool
+(ns oc.unit.db.pool
   (:require [midje.sweet :refer :all]
-            [oc.lib.rethinkdb.pool :as p]))
+            [oc.lib.db.pool :as p]))
 
 (facts "about claiming & releasing pool inventory"
   (let [x (atom 0)


### PR DESCRIPTION
Some of the changes to support `access` branches of API and Auth. Not all of them though, many were done to mainline before release `0.2.4` on Jan. 30.

Changes:

0.2.4 - added HATEOAS `remove` rel link w/ no media-type
0.3.0 - moved oc.lib.api.common from Auth to oc.lib.
0.4.0 - differentiate `accept` and `content-type` in HATEOAS links
0.4.1 - allow `hateoas/delete-link` to accept optional args
0.5.0 - Optional extra HATEOAS link args as a map rather than optional arguments.
0.5.1 - Make extra map optional when using bare `hateoas/link-map` function.