### PR TITLE
History count in board response

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,7 @@
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
     [liberator "0.14.1"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
-    [amazonica "0.3.90"]
+    [amazonica "0.3.94"]
     ;; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [clj-jwt "0.1.1"]
     ;; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
@@ -33,7 +33,7 @@
     ;; Async programming tools https://github.com/ztellman/manifold
     [manifold "0.1.6"]
     ;; Data validation https://github.com/Prismatic/schema
-    [prismatic/schema "1.1.3"]
+    [prismatic/schema "1.1.4"]
     ;; Environment settings from different sources https://github.com/weavejester/environ
     [environ "1.1.0"]
     
@@ -51,7 +51,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.6.17-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.7.0-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})


### PR DESCRIPTION
This adds a group count query needed to efficiently count the # of entries for a board response.

For the PR, you should review the code, but testing is indirect in storage API.

See: https://github.com/open-company/open-company-api/pull/73