### PR TITLE
Log unhandled exceptions in SQS consumers

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -15,7 +15,7 @@
     ; Component Lifecycle https://github.com/stuartsierra/component
     [com.stuartsierra/component "0.3.2"] 
     ;; Pure Clojure/Script logging library https://github.com/ptaoussanis/timbre
-    [com.taoensso/timbre "4.9.0-alpha1"]
+    [com.taoensso/timbre "4.10.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [raven-clj "1.5.0"]
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
@@ -32,7 +32,7 @@
     [clj-time "0.13.0"]
     ;; AWS SQS consumer https://github.com/TheClimateCorporation/squeedo
     [com.climate/squeedo "0.1.4"]
-    [org.slf4j/slf4j-nop "1.8.0-alpha0"] ; Squeedo dependency
+    [org.slf4j/slf4j-nop "1.8.0-alpha1"] ; Squeedo dependency
     ;; Data validation https://github.com/Prismatic/schema
     [prismatic/schema "1.1.5"]
     ;; Environment settings from different sources https://github.com/weavejester/environ
@@ -52,7 +52,7 @@
                   :username (System/getenv "CLOJARS_USER")
                   :password (System/getenv "CLOJARS_PASS")}}
  pom {:project 'open-company/lib
-      :version (str "0.8.1-" (subs (boot.git/last-commit) 0 7))
+      :version (str "0.8.2-" (subs (boot.git/last-commit) 0 7))
       :url "https://opencompany.com/"
       :scm {:url "https://github.com/open-company/open-company-lib"}
       :license {"MPL" "https://www.mozilla.org/media/MPL/2.0/index.txt"}})


### PR DESCRIPTION
https://trello.com/c/SMInMPRe

To test, follow the steps in `comments` in `oc.lib.sqs` to send a message that causes an unhandled exception in the consumer (replace `replace-me` in the `sqs-queue` var with a real SQS queue name).

In addition to the `println` output from the sample SQS consumer, you should see timbre log output for the error that looks like:

```
17-04-17 11:17:38 Seans-Mac-Pro.local ERROR [oc.lib.sqs:24] -
                                                       java.lang.Thread.run                       Thread.java:  745
                         java.util.concurrent.ThreadPoolExecutor$Worker.run           ThreadPoolExecutor.java:  617
                          java.util.concurrent.ThreadPoolExecutor.runWorker           ThreadPoolExecutor.java: 1142
                                                                        ...
                   clojure.core.async.impl.channels.ManyToManyChannel/fn/fn                      channels.clj:   95
                                clojure.core.async.impl.ioc-macros/take!/fn                    ioc_macros.clj:  986
               clojure.core.async.impl.ioc-macros/run-state-machine-wrapped                    ioc_macros.clj:  977
                       clojure.core.async.impl.ioc-macros/run-state-machine                    ioc_macros.clj:  973
   com.climate.squeedo.sqs-consumer/create-workers/fn/state-machine--auto--                  sqs_consumer.clj:   48
com.climate.squeedo.sqs-consumer/create-workers/fn/state-machine--auto--/fn                  sqs_consumer.clj:   48
                                                    clojure.core/partial/fn                          core.clj: 2598
                                                     oc.lib.sqs/log-handler                           sqs.clj:   22
                                                     boot.user/test-handler  boot.user4733971615333105813.clj:    6
                                                                        ...
java.lang.ArithmeticException: Divide by zero
```

Used by these 2 branches (no PRs for them, they are just 1 line commits):

[Email](https://github.com/open-company/open-company-email/tree/sqs-error-log)
[Bot](https://github.com/open-company/open-company-bot/tree/sqs-error-log)

- Review the code
- Test at the REPL
- Merge the 3 PRs
- Deploy email and bot
- Sip an adult beverage