### PR TITLE
Phase 3: Slack commenting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.6"
+(defproject open-company/lib "0.11.7"
   :description "OpenCompany Lib"
   :url "https://opencompany.com/"
   :license {
@@ -27,7 +27,7 @@
     [com.taoensso/sente "1.11.0"] ; WebSocket server https://github.com/ptaoussanis/sente
     [raven-clj "1.5.0"] ; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [liberator "0.14.1"] ; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
-    [amazonica "0.3.102"] ; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
+    [amazonica "0.3.103"] ; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
     [clj-jwt "0.1.1"] ; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [com.apa512/rethinkdb "0.15.26"] ; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
     [cheshire "5.7.1"] ; JSON encoding / decoding https://github.com/dakrone/cheshire

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.4"
+(defproject open-company/lib "0.11.5"
   :description "OpenCompany Lib"
   :url "https://opencompany.com/"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.7"
+(defproject open-company/lib "0.11.9"
   :description "OpenCompany Lib"
   :url "https://opencompany.com/"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.3"
+(defproject open-company/lib "0.11.4"
   :description "OpenCompany Lib"
   :url "https://opencompany.com/"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.5"
+(defproject open-company/lib "0.11.6"
   :description "OpenCompany Lib"
   :url "https://opencompany.com/"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.2"
+(defproject open-company/lib "0.11.3"
   :description "OpenCompany Lib"
   :url "https://opencompany.com/"
   :license {
@@ -19,7 +19,7 @@
     [defun "0.3.0-RC1"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     [lockedon/if-let "0.1.0"] ; More than one binding for if/when macros https://github.com/LockedOn/if-let
     [com.stuartsierra/component "0.3.2"] ; Component Lifecycle https://github.com/stuartsierra/component
-    [http-kit "2.3.0-alpha2"] ; Web server http://http-kit.org/
+    [http-kit "2.3.0-alpha2"] ; HTTP client and server http://http-kit.org/
     [ring/ring-codec "1.0.1"] ; Utility function for encoding and decoding data https://github.com/ring-clojure/ring-codec
     ;; NB: Timbre needs to come before Sente due to conflicts in shared dependency: com.taoensso/encore
     [com.taoensso/timbre "4.10.0"] ; Pure Clojure/Script logging library https://github.com/ptaoussanis/timbre
@@ -27,7 +27,7 @@
     [com.taoensso/sente "1.11.0"] ; WebSocket server https://github.com/ptaoussanis/sente
     [raven-clj "1.5.0"] ; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [liberator "0.14.1"] ; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
-    [amazonica "0.3.101"] ; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
+    [amazonica "0.3.102"] ; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
     [clj-jwt "0.1.1"] ; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [com.apa512/rethinkdb "0.15.26"] ; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
     [cheshire "5.7.1"] ; JSON encoding / decoding https://github.com/dakrone/cheshire

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -220,16 +220,24 @@
         (r/max select-by)
         (r/run conn)))))
 
-(defn update-resource
+(defun update-resource
   "
   Given a table name, the name of the primary key, and the original and updated resource,
   update a resource in the DB, returning the property map for the resource.
   "
-  ([conn table-name primary-key-name original-resource new-resource]
+  ([conn table-name primary-key-name original-resource :guard map? new-resource]
   (update-resource conn table-name primary-key-name original-resource new-resource (current-timestamp)))
 
-  ([conn table-name primary-key-name original-resource new-resource timestamp]
-  {:pre [(conn? conn)]}
+  ([conn table-name primary-key-name primary-key-value new-resource]
+  (if-let [original-resource (read-resource conn table-name primary-key-value)]
+    (update-resource conn table-name primary-key-name original-resource (merge original-resource new-resource))))
+
+  ([conn :guard conn?
+    table-name :guard s-or-k?
+    primary-key-name :guard s-or-k?
+    original-resource :guard map?
+    new-resource :guard map?
+    timestamp :guard string?]
   (let [timed-resource (merge new-resource {
           primary-key-name (original-resource primary-key-name)
           :created-at (:created-at original-resource)

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -222,8 +222,9 @@
 
 (defun update-resource
   "
-  Given a table name, the name of the primary key, and the original and updated resource,
-  update a resource in the DB, returning the property map for the resource.
+  Given a table name, the name of the primary key, an optional original resource (for efficiency if it's already
+  been retrieved) and the updated resource, update the resource in the DB, returning the property map for the
+  updated resource.
   "
   ([conn table-name primary-key-name original-resource :guard map? new-resource]
   (update-resource conn table-name primary-key-name original-resource new-resource (current-timestamp)))

--- a/src/oc/lib/schema.clj
+++ b/src/oc/lib/schema.clj
@@ -88,6 +88,13 @@
   :user-id UniqueID
   :avatar-url (schema/maybe schema/Str)})
 
+(def SlackMirror {
+  :slack-org-id NonBlankStr
+  :channel-name NonBlankStr
+  :channel-id NonBlankStr})
+
+(def SlackThread (assoc SlackMirror :thread NonBlankStr))
+
 (def Conn (schema/pred conn?))
 
 (def User

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -120,8 +120,8 @@
   ([bot-token channel timestamp text author]
   (slack-api :chat.postMessage {:token bot-token
                                 :text (as-proxy text author)
-                                :ts timestamp
                                 :channel channel
+                                :thread_ts timestamp
                                 :unfurl_links false})))
 
 

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -5,6 +5,9 @@
             [cheshire.core :as json]
             [taoensso.timbre :as timbre]))
 
+;; https://www.cs.tut.fi/~jkorpela/chars/spaces.html
+(def marker-char (char 8203)) ; U+200B a Unicode zero width space, used to mark comment messages originating with OC
+
 (defn- as-echo
   "
   Anything we send into Slack, include a marker (a Unicode non-width space) so we know it was from us.
@@ -12,7 +15,7 @@
   This is especially useful when getting incoming message events from Slack.
   "
   [text]
-  (str (char 8203) text))
+  (str marker-char text))
 
 (defn- as-proxy
   "Manually attribute the message to the person that said it with an English attribution."

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -1,0 +1,156 @@
+(ns oc.lib.slack
+  "Make simple (not web socket) Slack Web API HTTP requests and extract the response."
+  (:require [clojure.walk :refer (keywordize-keys)]
+            [org.httpkit.client :as http]
+            [cheshire.core :as json]
+            [taoensso.timbre :as timbre]))
+
+(defn- as-echo
+  "
+  Anything we send into Slack, include a marker (a Unicode non-width space) so we know it was from us.
+  
+  This is especially useful when getting incoming message events from Slack.
+  "
+  [text]
+  (str (char 8203) text))
+
+(defn- as-proxy
+  "Manually attribute the message to the person that said it with an English attribution."
+  [text author]
+  (as-echo (str author " said:\n" text)))
+
+(defn- with-reply
+  "Given the text of a message, append a link to a threaded discussion to the message."
+  [text channel timestamp]
+  (let [ts (clojure.string/replace timestamp #"\." "")]
+    (str text "\n\n<https://opencompanyhq.slack.com/conversation/" channel "/p" ts "|Reply>")))
+
+(defn slack-api [method params]
+  (timbre/info "Making slack request:" method)
+  (let [url (str "https://slack.com/api/" (name method))
+        {:keys [status headers body error] :as resp} @(http/get url {:query-params params :as :text})]
+    (if error
+      (throw (ex-info "Error from Slack API"
+                {:method method
+                 :params params
+                 :status status
+                 :body body}))
+      (-> body json/decode keywordize-keys))))
+
+(defn get-team-info [token]
+  (:team (slack-api :team.info {:token token})))
+
+(defn get-users [token]
+  (:members (slack-api :users.list {:token token})))
+
+(defn get-dm-channel [token user-id]
+  (-> (slack-api :im.open {:token token :user user-id}) :channel :id))
+
+(defn get-channels [token]
+  (:channels (slack-api :channels.list {:token token})))
+
+(defn post-message
+  "Post a message as the bot."
+  [bot-token channel text]
+  (slack-api :chat.postMessage {:token bot-token
+                                :text text
+                                :channel channel
+                                :unfurl_links false}))
+
+(defn- link-comment-to-thread
+  "Update the message in Slack to include a link to a threaded discussion."
+  ([token channel timestamp text]
+  (slack-api :chat.update {:token token
+                           :text (-> text as-echo (with-reply channel timestamp))
+                           :ts timestamp
+                           :channel channel
+                           :parse "none"
+                           :unfurl_links false
+                           :as-user true}))
+
+  ([token channel timestamp text author]
+  (slack-api :chat.update {:token token
+                           :text (-> text (as-proxy author) (with-reply channel timestamp))
+                           :ts timestamp
+                           :channel channel
+                           :parse "none"
+                           :unfurl_links false})))
+
+(defn echo-comment
+  "Pass along a comment to a Slack channel, impersonating the user that authored the comment."
+  ([user-token channel text]
+  (let [result (slack-api :chat.postMessage {:token user-token
+                                             :text (as-echo text)
+                                             :channel channel
+                                             :unfurl_links false
+                                             :as_user true})
+        timestamp (:ts result)]
+    ;; If the initial message was successfully posted, edit it to include a link to a thread
+    (if (and (:ok result) timestamp)
+      (link-comment-to-thread user-token channel timestamp text)
+      result)))
+  
+  ([user-token channel timestamp text]
+  (slack-api :chat.postMessage {:token user-token
+                                :text (as-echo text)
+                                :channel channel
+                                :ts timestamp
+                                :unfurl_links false
+                                :as_user true})))
+
+(defn proxy-comment
+  "
+  Pass along a comment to a Slack channel -or- a thread of a channel, using the bot and mentioning the user that
+  authored the comment.
+  "
+  ([bot-token channel text author]
+  (let [result (slack-api :chat.postMessage {:token bot-token
+                                             :text (as-proxy text author)
+                                             :channel channel
+                                             :unfurl_links false})
+        timestamp (:ts result)]
+    ;; If the initial message was successfully posted, edit it to include a link to a thread
+    (if (and (:ok result) timestamp)
+      (link-comment-to-thread bot-token channel timestamp text author)
+      result)))
+
+  ([bot-token channel timestamp text author]
+  (slack-api :chat.postMessage {:token bot-token
+                                :text (as-proxy text author)
+                                :ts timestamp
+                                :channel channel
+                                :unfurl_links false})))
+
+
+(comment
+
+  (require '[oc.lib.slack :as slack] :reload)
+  (def bot-token "<bot-token>")
+
+  (slack/get-team-info bot-token)
+  
+  (slack/get-users bot-token)
+
+  (slack/get-channels bot-token)
+
+  (slack/get-users bot-token)
+
+  ;; Message to channel as a bot
+  (def bot-channels (slack/get-channels bot-token))
+  (slack/post-message bot-token (-> bot-channels first :id) "Test message from the bot.")
+
+  ;; DM to user as a bot
+  (def user-id "<user-id>")
+  (def dm-channel (slack/get-dm-channel bot-token user-id))
+  (slack/post-message bot-token dm-channel "Test DM from the bot.")
+
+  ;; Echo a comment as a user
+  (def user-token "<user-token>")
+  (def user-channels (slack/get-channels user-token))
+  (slack/echo-comment user-token (-> user-channels first :id) "Comment as user.")
+
+  ;; Proxy a comment for a user
+  (def bot-channels (slack/get-channels bot-token))
+  (slack/proxy-comment user-token (-> user-channels first :id) "Comment by a user." "Albert Camus")
+
+  )

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -71,7 +71,7 @@
   ([token channel timestamp text author]
   (slack-api :chat.update {:token token
                            :text (-> text (as-proxy author) (with-reply channel timestamp))
-                           :ts timestamp
+                           :thread_ts timestamp
                            :channel channel
                            :parse "none"
                            :unfurl_links false})))
@@ -94,7 +94,7 @@
   (slack-api :chat.postMessage {:token user-token
                                 :text (as-echo text)
                                 :channel channel
-                                :ts timestamp
+                                :thread_ts timestamp
                                 :unfurl_links false
                                 :as_user true})))
 


### PR DESCRIPTION
Supports: https://github.com/open-company/open-company-interaction/pull/3

Changes to review for:

- Allow a DB resource to be updated w/o providing the original resource map.
- Schema for storing Slack mirror (channel to mirror to) and Slack thread (channel/thread where an entry has been mirrored to)
- Move bot's Slack API into oc.lib since it's now shared between Bot and Interaction services.
