### PR TITLE
All activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > -- [Dharmesh Shah](https://twitter.com/dharmesh)
 
-Companies struggle to keep everyone on the same page. People are hyper-connected in the moment but still don’t know what’s happening across the company. Employees and investors, co-founders and execs, customers and community, they all want more transparency. The solution is surprisingly simple and effective - great company updates that build transparency and alignment.
+Companies struggle to keep everyone on the same page. People are hyper-connected in the moment but still don't know what's happening across the company. Employees and investors, co-founders and execs, customers and community, they all want more transparency. The solution is surprisingly simple and effective - great company updates that build transparency and alignment.
 
 With that in mind we designed the [Carrot](https://carrot.io/) software-as-a-service application, powered by the open source [OpenCompany platform](https://github.com/open-company). The product design is based on three principles:
 
@@ -73,7 +73,7 @@ lein deps
 
 ## Usage
 
-To use this library in your other projcets, include the following in your dependencies:
+To use this library in your other projects, include the following in your dependencies:
 
 [![Clojars Project](https://img.shields.io/clojars/v/open-company/lib.svg)](https://clojars.org/open-company/lib)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.12.0"
+(defproject open-company/lib "0.12.1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.12.1"
+(defproject open-company/lib "0.12.2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
   :dependencies [
     [org.clojure/clojure "1.9.0-alpha17" :scope "provided"] ; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/core.async "0.3.443"] ; Async programming and communication https://github.com/clojure/core.async
-    [org.clojure/core.match "0.3.0-alpha4"] ; Erlang-esque pattern matching https://github.com/clojure/core.match
+    [org.clojure/core.match "0.3.0-alpha5"] ; Erlang-esque pattern matching https://github.com/clojure/core.match
     [defun "0.3.0-RC1"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     [lockedon/if-let "0.1.0"] ; More than one binding for if/when macros https://github.com/LockedOn/if-let
     [com.stuartsierra/component "0.3.2"] ; Component Lifecycle https://github.com/stuartsierra/component
@@ -27,7 +27,7 @@
     [com.taoensso/sente "1.11.0"] ; WebSocket server https://github.com/ptaoussanis/sente
     [raven-clj "1.5.0"] ; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [liberator "0.15.1"] ; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
-    [amazonica "0.3.107"] ; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
+    [amazonica "0.3.108"] ; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
     [clj-jwt "0.1.1"] ; A Clojure library for JSON Web Token(JWT) https://github.com/liquidz/clj-jwt
     [com.apa512/rethinkdb "0.15.26"] ; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
     [cheshire "5.7.1"] ; JSON encoding / decoding https://github.com/dakrone/cheshire
@@ -50,7 +50,7 @@
       :plugins [
         [lein-midje "3.2.1"] ; Example-based testing https://github.com/marick/lein-midje
         [jonase/eastwood "0.2.4"] ; Linter https://github.com/jonase/eastwood
-        [lein-kibit "0.1.5"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
+        [lein-kibit "0.1.6-beta1"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
       ]
     }
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.12.2"
+(defproject open-company/lib "0.12.3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -50,7 +50,7 @@
       :plugins [
         [lein-midje "3.2.1"] ; Example-based testing https://github.com/marick/lein-midje
         [jonase/eastwood "0.2.4"] ; Linter https://github.com/jonase/eastwood
-        [lein-kibit "0.1.6-beta1"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
+        [lein-kibit "0.1.6-beta2"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
       ]
     }
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.11.15"
+(defproject open-company/lib "0.12.0"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -225,7 +225,7 @@
          (every? #(or (keyword? %) (string? %)) relation-fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])
         order-fn (if (= order :desc) r/desc r/asc)
-        filter-fn (if (= direction :before) r/ge r/le)]
+        filter-fn (if (= direction :before) r/gt r/lt)]
     (with-timeout default-timeout
       (-> (r/table table-name)
           (r/get-all index-values {:index index-name})

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -55,7 +55,7 @@
 (defmacro with-timeout
   "A basic macro to wrap things in a timeout.
   Will throw an exception if the operation times out.
-  Note: This is a simplistic approach and piggiebacks on core.asyncs executor-pool.
+  Note: This is a simplistic approach and piggybacks on core.asyncs executor-pool.
   Read this discussion for more info: https://gist.github.com/martinklepsch/0caf92b5e42eefa3a894"
   [ms & body]
   `(let [c# (async/thread-call #(do ~@body))]

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -7,7 +7,6 @@
             [clj-time.format :as format]
             [clj-time.core :as time]
             [rethinkdb.query :as r]
-            [rethinkdb.net :as rn]
             [oc.lib.schema :as lib-schema]))
 
 ;; ----- ISO 8601 timestamp -----

--- a/src/oc/lib/db/pool.clj
+++ b/src/oc/lib/db/pool.clj
@@ -66,13 +66,13 @@
       (future (grow this)))))
 
 (defn fixed-pool
-  "A fixed pool of thingys. (open) is called to generate a thingy. (close
-  thingy) is called when a thingy is invalidated. When thingys are invalidated,
+  "A fixed pool of thingies. (open) is called to generate a thingy. (close
+  thingy) is called when a thingy is invalidated. When thingies are invalidated,
   the pool will immediately try to open a new one; if open throws or returns
   nil, the pool will sleep for regenerate-interval seconds before retrying
   (open).
   :regenerate-interval    How long to wait between retrying (open).
-  :size                   Number of thingys in the pool.
+  :size                   Number of thingies in the pool.
   :block-start            Should (fixed-pool) wait until the pool is full
                           before returning?
   Note that fixed-pool is correct only if every successful (claim) is followed

--- a/src/oc/lib/proxy/sheets_chart.clj
+++ b/src/oc/lib/proxy/sheets_chart.clj
@@ -59,7 +59,7 @@
 
 (defn- proxy-sheets
   "
-  Proxy requests to Google Sheets (needed for CORs). Rewrite the respones in a form ready for embedding as
+  Proxy requests to Google Sheets (needed for CORs). Rewrite the responses in a form ready for embedding as
   an iFrame. Return the response as a ring response (map).
 
   Used in development by the Web development service. Used in production by the OpenCompany Proxy Service.
@@ -81,7 +81,7 @@
 
 (defn proxy-sheets-chart
   "
-  Proxy requests to Google Sheets and rewrite the respones in a form ready for embedding as
+  Proxy requests to Google Sheets and rewrite the responses in a form ready for embedding as
   an iFrame. Return the response as a ring response (map).
 
   Used in development by the Web development service. Used in production by the OpenCompany Proxy Service.


### PR DESCRIPTION
This PR supports: https://github.com/open-company/open-company-storage/pull/87

This PR changes common DB functions:

- checks for cursor responses and drains them to a seq in all `get-all` and full table functions
- adds a higher arity resources and relations fn that provides the fine control needed for activity timeline

To test:

- Generate 6 months+ of update data with the new storage data generator
- Use the regular storage APIs, no blank API responses in board operations due to cursors? No regressions in normal storage API usage from the UI?
- Use the activity timeline / calendar API from the UI