### PR TITLE
Digest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.14.13"
+(defproject open-company/lib "0.14.14"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -16,7 +16,7 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.9.0" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
-    [org.clojure/core.async "0.3.465"]
+    [org.clojure/core.async "0.4.474"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha5"]
     ;; Clojure reader https://github.com/clojure/tools.reader

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.14.10"
+(defproject open-company/lib "0.14.11"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.14.11"
+(defproject open-company/lib "0.14.12"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.14.12"
+(defproject open-company/lib "0.14.13"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -115,7 +115,7 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (s-or-k? index-name)
-         (or (s-or-k? index-value) (and (sequential? index-value) (every? s-or-k? index-value)))]}
+         (or (s-or-k? index-value) (sequential? index-value))]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
     (with-timeout default-timeout
        (-> (r/table table-name)
@@ -127,7 +127,7 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (s-or-k? index-name)
-         (or (s-or-k? index-value) (and (sequential? index-value) (every? s-or-k? index-value)))
+         (or (s-or-k? index-value) (sequential? index-value))
          (sequential? fields)
          (every? s-or-k? fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
@@ -142,7 +142,7 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (s-or-k? index-name)
-         (or (s-or-k? index-value) (and (sequential? index-value) (every? s-or-k? index-value)))
+         (or (s-or-k? index-value) (sequential? index-value))
          (sequential? fields)
          (every? s-or-k? fields)
          (number? limit)]}

--- a/src/oc/lib/db/common.clj
+++ b/src/oc/lib/db/common.clj
@@ -104,7 +104,7 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (sequential? fields)
-         (every? #(or (keyword? %) (string? %)) fields)]}
+         (every? s-or-k? fields)]}
   (with-timeout default-timeout
     (-> (r/table table-name)
         (r/with-fields fields)
@@ -115,7 +115,7 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (s-or-k? index-name)
-         (or (string? index-value) (sequential? index-value))]}
+         (or (s-or-k? index-value) (and (sequential? index-value) (every? s-or-k? index-value)))]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
     (with-timeout default-timeout
        (-> (r/table table-name)
@@ -127,9 +127,9 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (s-or-k? index-name)
-         (or (string? index-value) (sequential? index-value))
+         (or (s-or-k? index-value) (and (sequential? index-value) (every? s-or-k? index-value)))
          (sequential? fields)
-         (every? #(or (keyword? %) (string? %)) fields)]}
+         (every? s-or-k? fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
     (with-timeout default-timeout
       (-> (r/table table-name)
@@ -142,9 +142,9 @@
   {:pre [(conn? conn)
          (s-or-k? table-name)
          (s-or-k? index-name)
-         (or (string? index-value) (sequential? index-value))
+         (or (s-or-k? index-value) (and (sequential? index-value) (every? s-or-k? index-value)))
          (sequential? fields)
-         (every? #(or (keyword? %) (string? %)) fields)
+         (every? s-or-k? fields)
          (number? limit)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
     (with-timeout default-timeout
@@ -214,7 +214,7 @@
          (s-or-k? relation-field-name)
          (s-or-k? relation-index-name)
          (sequential? relation-fields)
-         (every? #(or (keyword? %) (string? %)) relation-fields)]}
+         (every? s-or-k? relation-fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])]
     (with-timeout default-timeout
       (-> (r/table table-name)
@@ -244,7 +244,7 @@
          (s-or-k? relation-field-name)
          (s-or-k? relation-index-name)
          (sequential? relation-fields)
-         (every? #(or (keyword? %) (string? %)) relation-fields)]}
+         (every? s-or-k? relation-fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])
         order-fn (if (= order :desc) r/desc r/asc)
         filter-fn (if (= direction :before) r/gt r/lt)]
@@ -282,7 +282,7 @@
          (s-or-k? relation-field-name)
          (s-or-k? relation-index-name)
          (sequential? relation-fields)
-         (every? #(or (keyword? %) (string? %)) relation-fields)]}
+         (every? s-or-k? relation-fields)]}
   (let [index-values (if (sequential? index-value) index-value [index-value])
         order-fn (if (= order :desc) r/desc r/asc)
         filter-fn (if (= direction :before) r/gt r/lt)]
@@ -325,7 +325,7 @@
          (sequential? primary-keys)
          (every? string? primary-keys)
          (sequential? fields)
-         (every? #(or (keyword? %) (string? %)) fields)]}
+         (every? s-or-k? fields)]}
   (with-timeout default-timeout
     (-> (r/table table-name)
         (r/get-all primary-keys)


### PR DESCRIPTION
Supports: https://trello.com/c/YBUH0SR6

This mainly moves some code involved in creating JWTokens from Auth to oc.lib so it can be shared with the Digest service.

In addition, `digest` is in the schema now as a valid source of JWToken requests.

Also does a little minor cleanup, using the `s-or-k?` validation we have in some other places it can be used.

Just review the code. The code has been tested, it's from Auth. Just being moved here. Regression tests will happen in Auth PR to come.

Nothing to do "deploy" wise, this version is already out on Clojars.
  
  
  