### PR TITLE
Shared attribution fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.14.14"
+(defproject open-company/lib "0.14.15"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/slugify.clj
+++ b/src/oc/lib/slugify.clj
@@ -1,4 +1,5 @@
 (ns oc.lib.slugify
+  "Functions for creating URL safe slugs from text strings."
   (:require [clojure.string :as s])
   (:import [java.text Normalizer Normalizer$Form]))
 

--- a/src/oc/lib/text.clj
+++ b/src/oc/lib/text.clj
@@ -1,0 +1,35 @@
+(ns oc.lib.text
+  "Functions related to processing text.")
+
+(defn attribution
+  "
+  Given the number of distinct authors to mention, the number of items, what to call the
+  item (needs to pluralize with just an 's'), and a sequence of authors of the items
+  to attribute (sequence needs to be distinct'able, and have a `:name` property per author),
+  return a text string that attributes the authors to the items.
+
+  E.g.
+
+  (attribution 3 7 'comment' [{:name 'Joe'} {:name 'Joe'} {:name 'Moe'} {:name 'Flo'} {:name 'Flo'} {:name 'Sue'}])
+  '7 comments by Joe, Moe, Flo and others'
+  "
+  [attribution-count item-count item-name authors]
+  (let [distinct-authors (distinct authors)
+        author-names (map :name (take attribution-count distinct-authors))
+        more-authors? (> (count distinct-authors) (count author-names))
+        multiple-authors? (> (count author-names) 1)
+        author-attribution (cond
+                              ;; more distinct authors than we are going to mention
+                              more-authors?
+                              (str (clojure.string/join ", " author-names) " and others")
+                                                        
+                              ;; more than 1 author so last mention needs an "and", not a comma
+                              multiple-authors?
+                              (str (clojure.string/join ", " (butlast author-names))
+                                                        " and "
+                                                        (last author-names))
+
+                              ;; just 1 author
+                              :else
+                              (first author-names))]
+    (str item-count " " item-name (when (> item-count 1) "s") " by " author-attribution)))

--- a/src/oc/lib/text.clj
+++ b/src/oc/lib/text.clj
@@ -22,7 +22,7 @@
                               ;; more distinct authors than we are going to mention
                               more-authors?
                               (str (clojure.string/join ", " author-names) " and others")
-                                                        
+
                               ;; more than 1 author so last mention needs an "and", not a comma
                               multiple-authors?
                               (str (clojure.string/join ", " (butlast author-names))

--- a/test/oc/unit/text.clj
+++ b/test/oc/unit/text.clj
@@ -4,7 +4,7 @@
 
 (def item "foo")
 
-(def authors [{:name "Sean"} {:name "Sean"} {:name "Nathan"} {:name "Nathan"} {:name "Sean"} 
+(def authors [{:name "Sean"} {:name "Sean"} {:name "Nathan"} {:name "Nathan"} {:name "Sean"}
               {:name "Stuart"} {:name "Stuart"} {:name "Iacopo"} {:name "Iacopo"} {:name "Ryan"}])
 
 (facts "about making attributions"

--- a/test/oc/unit/text.clj
+++ b/test/oc/unit/text.clj
@@ -1,0 +1,21 @@
+(ns oc.unit.text
+  (:require [midje.sweet :refer :all]
+            [oc.lib.text :refer (attribution)]))
+
+(def item "foo")
+
+(def authors [{:name "Sean"} {:name "Sean"} {:name "Nathan"} {:name "Nathan"} {:name "Sean"} 
+              {:name "Stuart"} {:name "Stuart"} {:name "Iacopo"} {:name "Iacopo"} {:name "Ryan"}])
+
+(facts "about making attributions"
+  (attribution 3 1 item (take 1 authors)) => "1 foo by Sean"
+  (attribution 3 2 item (take 2 authors)) => "2 foos by Sean"
+  (attribution 3 3 item (take 3 authors)) => "3 foos by Sean and Nathan"
+  (attribution 3 4 item (take 4 authors)) => "4 foos by Sean and Nathan"
+  (attribution 3 6 item (take 6 authors)) => "6 foos by Sean, Nathan and Stuart"
+  (attribution 3 8 item (take 8 authors)) => "8 foos by Sean, Nathan, Stuart and others"
+  (attribution 3 8 item (take 8 authors)) => "8 foos by Sean, Nathan, Stuart and others"
+  (attribution 3 10 item authors) => "10 foos by Sean, Nathan, Stuart and others"
+  (attribution 4 10 item authors) => "10 foos by Sean, Nathan, Stuart, Iacopo and others"
+  (attribution 5 10 item authors) => "10 foos by Sean, Nathan, Stuart, Iacopo and Ryan"
+  (attribution 1 10 item authors) => "10 foos by Sean and others")


### PR DESCRIPTION
Supports: https://trello.com/c/YBUH0SR6

Add a text processing ns and an attribution function that builds human readable authorship attribution.

At this point this fn is shared by bot and email to attribute comments.

- [x] Review the code
- [x] Review the tests
- [x] Run the tests (or check them in CI)
- [ ] Merge
- [ ] No deploy step, already on clojars 
- [ ] Prey to the god of lucky punks like you