### PR TITLE
Fix Slack -> Carrot comments

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.0"
+(defproject open-company/lib "0.16.1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.1"
+(defproject open-company/lib "0.16.2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -21,7 +21,7 @@
     [org.clojure/core.match "0.3.0-alpha5"]
     ;; Clojure reader https://github.com/clojure/tools.reader
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
-    [org.clojure/tools.reader "1.2.1"]
+    [org.clojure/tools.reader "1.2.2"]
     ;; Tools for writing macros https://github.com/clojure/tools.macro
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [org.clojure/tools.macro "0.1.5"]

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -51,7 +51,7 @@
   "Post a message as the bot."
   [bot-token channel text]
   (slack-api :chat.postMessage {:token bot-token
-                                :text text
+                                :text (with-marker text)
                                 :channel channel
                                 :unfurl_links false}))
 

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -102,10 +102,12 @@
   ([user-token channel initial-text reply-text]
   (let [result (slack-api :chat.postMessage (echo-data user-token channel initial-text))
         timestamp (:ts result)]
-    ;; If the initial message was successfully posted, edit it to include a link to a thread
-    (if (and (:ok result) timestamp)
-      (echo-message user-token channel timestamp reply-text)
-      result))))
+    
+    ;; If the initial message was successfully posted, reply to it with the 2nd part of the message
+    (when (and (:ok result) timestamp)
+      (echo-message user-token channel timestamp reply-text))
+    
+    result)))
 
 (defun proxy-message
   "
@@ -128,10 +130,12 @@
   ([bot-token channel initial-text reply-text]
   (let [result (slack-api :chat.postMessage (post-data bot-token channel initial-text))
         timestamp (:ts result)]
-    ;; If the initial message was successfully posted, edit it to include a link to a thread
-    (if (and (:ok result) timestamp)
-      (proxy-message bot-token channel timestamp reply-text)
-      result))))
+    
+    ;; If the initial message was successfully posted, reply to it with the 2nd part of the message
+    (when (and (:ok result) timestamp)
+      (proxy-message bot-token channel timestamp reply-text))
+    
+    result)))
 
 (comment
 
@@ -158,10 +162,12 @@
   ;; Echo a comment as a user
   (def user-token "<user-token>")
   (def user-channels (slack/get-channels user-token))
-  (slack/echo-message user-token (-> user-channels first :id) "Comment as user.")
+  (slack/echo-message user-token (-> user-channels first :id) "Comment as user." "This is my first comment.")
+  (slack/echo-message user-token (-> user-channels first :id) "This is my second comment.")
 
   ;; Proxy a comment for a user
   (def bot-channels (slack/get-channels bot-token))
-  (slack/proxy-message user-token (-> user-channels first :id) "Albert Camus said: Comment by a user.")
+  (slack/proxy-message bot-token (-> user-channels first :id) "Albert Camus said:" "This is my first comment.")
+  (slack/proxy-message bot-token (-> user-channels first :id) "Albert Camus said: This is my second comment.")
 
   )


### PR DESCRIPTION
https://trello.com/c/DG4A0YwJ

This PR supports: https://github.com/open-company/open-company-bot/pull/22

Echoing from Slack back into Carrot was broken with `0.16.0` as we ended up returning the child message rather than the parent in the new reply scheme, which means the thread lookup on inbound Slack messages always failed.

This fixes the return of echo and proxy so they return the initial message, not the reply. The timestamp of the return is stored by interaction services for thread lookup.

In addition, this PR adds the invisible Unicode marker to messages we send to Slack with the `post-message` fn which is used directly in some places, this brings it inline with `post-message` and `echo-message`.

- [x] Review the code
- [x] Test with [Bot services PR](https://github.com/open-company/open-company-bot/pull/22)
- [x] No deploy needed, already on Clojars
- [ ] Feed the birds