### PR TITLE
Allow a single client id to unwatch all watches.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.2"
+(defproject open-company/lib "0.16.3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/async/watcher.clj
+++ b/src/oc/lib/async/watcher.clj
@@ -38,7 +38,7 @@
   ([watch-id client-id]
      (let [item-watchers (or (get @watchers watch-id) #{})]
        (swap! watchers assoc watch-id (disj item-watchers client-id))
-       (when (empty? (get @watchers watch-id))
+       (when (not (contains? (get @watchers watch-id) client-id))
          (swap! watchers dissoc client-id)))))
 
 (defn watchers-for [watch-id]

--- a/src/oc/lib/async/watcher.clj
+++ b/src/oc/lib/async/watcher.clj
@@ -8,7 +8,7 @@
   The sending to registered listeners is the resposibility of the user of this watcher and is
   done by consuming the core.async `sender-chan` from this namespace.
   "
-  (:require [clojure.core.async :as async :refer [<!! >!!]]
+  (:require [clojure.core.async :as async :refer [<! >!!]]
             [defun.core :refer (defun-)]
             [taoensso.timbre :as timbre]))
 
@@ -24,12 +24,22 @@
 (def watchers (atom {}))
 
 (defn add-watcher [watch-id client-id]
-  (let [item-watchers (or (get @watchers watch-id) #{})]
-    (swap! watchers assoc watch-id (conj item-watchers client-id))))
+  (let [item-watchers (or (get @watchers watch-id) #{})
+        watcher-ids (or (get @watchers client-id) #{})]
+    (swap! watchers assoc client-id (conj watcher-ids watch-id)
+                          watch-id (conj item-watchers client-id))))
 
-(defn remove-watcher [watch-id client-id]
-  (let [item-watchers (or (get @watchers watch-id) #{})]
-    (swap! watchers assoc watch-id (disj item-watchers client-id))))
+(defn remove-watcher
+  ([client-id]
+     (let [watcher-ids (or (get @watchers client-id) #{})]
+       (doseq [watch-id watcher-ids]
+         (remove-watcher watch-id client-id))))
+
+  ([watch-id client-id]
+     (let [item-watchers (or (get @watchers watch-id) #{})]
+       (swap! watchers assoc watch-id (disj item-watchers client-id))
+       (when (empty? (get @watchers watch-id))
+         (swap! watchers dissoc client-id)))))
 
 (defn watchers-for [watch-id]
   (vec (get @watchers watch-id)))
@@ -56,8 +66,14 @@
   ;; Unregister interest by the specified client in the specified item by removing the client ID
   (let [watch-id (:watch-id message)
         client-id (:client-id message)]
-    (timbre/info "Stop watch request for:" watch-id "by:" client-id)
-    (remove-watcher watch-id client-id)))
+    (if watch-id
+      (do
+        (timbre/info "Stop watch request for:" watch-id "by:" client-id)
+        (remove-watcher watch-id client-id))
+      (do
+        (timbre/info "Stop watch request by:" client-id)
+        (remove-watcher client-id))
+    )))
 
   ([message :guard :send]
   ;; For every client that's registered interest in the specified item, send them the specified event
@@ -79,7 +95,7 @@
   (reset! watcher-go true)
   (async/go (while @watcher-go
     (timbre/debug "Watcher waiting...")
-    (let [message (<!! watcher-chan)]
+    (let [message (<! watcher-chan)]
       (timbre/debug "Processing message on watcher channel...")
       (if (:stop message)
         (do (reset! watcher-go false) (timbre/info "Watcher stopped."))

--- a/src/oc/lib/async/watcher.clj
+++ b/src/oc/lib/async/watcher.clj
@@ -38,7 +38,7 @@
   ([watch-id client-id]
      (let [item-watchers (or (get @watchers watch-id) #{})]
        (swap! watchers assoc watch-id (disj item-watchers client-id))
-       (when (not (contains? (get @watchers watch-id) client-id))
+       (when-not (contains? (get @watchers watch-id) client-id)
          (swap! watchers dissoc client-id)))))
 
 (defn watchers-for [watch-id]


### PR DESCRIPTION
This change uses the non-blocking, aka parking async channel reader.

It also supports the ability to unwatch all watches by the client id.  This is useful so that the client doesn't have to keep track of all their watches and can remove all on disconnect or if they want to "clear" all watches.

The watchers hashmap now contains a client id key used to lookup all the client's watches.

This can be tested with the steps seen here https://github.com/open-company/open-company-web/pull/395