### PR TITLE
Unfurl slack url

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.3"
+(defproject open-company/lib "0.16.5"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -121,7 +121,7 @@
   [payload passphrase]
   (let [expiring-payload (expire payload)]
     (when (not (:super-user expiring-payload)) ;; trust the super user
-      (schema/validate Claims expiring-payload) ; ensure we only generate valid JWTokens
+      (schema/validate Claims expiring-payload)) ; ensure we only generate valid JWTokens
     (-> expiring-payload
         jwt/jwt
         (jwt/sign :HS256 passphrase)

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -120,7 +120,8 @@
   "Create a JSON Web Token from a payload."
   [payload passphrase]
   (let [expiring-payload (expire payload)]
-    (schema/validate Claims expiring-payload) ; ensure we only generate valid JWTokens
+    (when (not (:super-user expiring-payload)) ;; trust the super user
+      (schema/validate Claims expiring-payload) ; ensure we only generate valid JWTokens
     (-> expiring-payload
         jwt/jwt
         (jwt/sign :HS256 passphrase)

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -120,7 +120,7 @@
   "Create a JSON Web Token from a payload."
   [payload passphrase]
   (let [expiring-payload (expire payload)]
-    (when (not (:super-user expiring-payload)) ;; trust the super user
+    (when-not (:super-user expiring-payload) ;; trust the super user
       (schema/validate Claims expiring-payload)) ; ensure we only generate valid JWTokens
     (-> expiring-payload
         jwt/jwt

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -64,6 +64,13 @@
                                 :attachments (json/encode attachments)
                                 :channel channel}))
 
+(defn unfurl-post-url
+  "Add data to the url when a Carrot url is posted in slack."
+  [user-token channel url url-text]
+  (slack-api :chat.unfurl {:token user-token
+                           :channel channel
+                           :unfurls (json/encode {url {:text url-text}})}))
+
 (defn- slack-timestamp?
   "
   Slack timestamps look like: 1518175926.000301

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -66,9 +66,10 @@
 
 (defn unfurl-post-url
   "Add data to the url when a Carrot url is posted in slack."
-  [user-token channel url url-text]
+  [user-token channel ts url url-text]
   (slack-api :chat.unfurl {:token user-token
                            :channel channel
+                           :message_ts ts
                            :unfurls (json/encode {url {:text url-text}})}))
 
 (defn- slack-timestamp?

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -66,11 +66,11 @@
 
 (defn unfurl-post-url
   "Add data to the url when a Carrot url is posted in slack."
-  [user-token channel ts url url-text]
+  [user-token channel ts url-data]
   (slack-api :chat.unfurl {:token user-token
                            :channel channel
                            :ts ts
-                           :unfurls (json/encode {url {:text url-text}})}))
+                           :unfurls url-data}))
 
 (defn- slack-timestamp?
   "

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -69,7 +69,7 @@
   [user-token channel ts url url-text]
   (slack-api :chat.unfurl {:token user-token
                            :channel channel
-                           :message_ts ts
+                           :ts ts
                            :unfurls (json/encode {url {:text url-text}})}))
 
 (defn- slack-timestamp?


### PR DESCRIPTION
Support for unfurl in the Slack API.

Also trust the new service "super-user" token for internal service requests.

This has already been deployed to clojars as version 0.16.5

This can be tested with the slack router since it uses this version.