### PR TITLE
Add the marker when posting attachments.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.5"
+(defproject open-company/lib "0.16.6"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -61,6 +61,7 @@
   {:pre [(sequential? attachments)
          (every? map? attachments)]}
   (slack-api :chat.postMessage {:token bot-token
+                                :text (with-marker "")
                                 :attachments (json/encode attachments)
                                 :channel channel}))
 


### PR DESCRIPTION
This change adds our marker to the text attribute of the attachments message. We need this marker so we know the message is from our bot.

To test:
- Run `lein install` locally to have the new lib available.
- Run the bot service with the branch here https://github.com/open-company/open-company-bot/pull/28
- Setup the slack router to receive message from slack with ngrok (see slack router README)
- Run the digest with `lein run-daily`  
Without the lib change you will see the bot help message.
- [x] With the updated lib you should no longer see the help message.
- [x] merge this branch
- [x] run `lein deploy release`