### PR TITLE
Slack names

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.12-alpha1"
+(defproject open-company/lib "0.16.12-alpha2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.12-alpha2"
+(defproject open-company/lib "0.16.12-alpha3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.10"
+(defproject open-company/lib "0.16.12-alpha1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -14,14 +14,14 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0" :scope "provided"]
+    [org.clojure/clojure "1.10.0-alpha6" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.4.474"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha5"]
     ;; Clojure reader https://github.com/clojure/tools.reader
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
-    [org.clojure/tools.reader "1.3.0-alpha3"]
+    [org.clojure/tools.reader "1.3.0"]
     ;; Tools for writing macros https://github.com/clojure/tools.macro
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [org.clojure/tools.macro "0.1.5"]
@@ -46,21 +46,21 @@
     [commons-codec "1.11"]
     ;; WebSocket server https://github.com/ptaoussanis/sente
     ;; NB: timbre is pulled in manually
-    [com.taoensso/sente "1.12.0" :exclusions [com.taoensso/timbre com.taoensso/encore]]
+    [com.taoensso/sente "1.13.0" :exclusions [com.taoensso/timbre com.taoensso/encore]]
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
     [com.taoensso/encore "2.96.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; NB: commons-codec pulled in manually
-    [raven-clj "1.5.1" :exclusions [commons-codec]]
+    [raven-clj "1.6.0-alpha" :exclusions [commons-codec]]
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
-    [liberator "0.15.1"] 
+    [liberator "0.15.2"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
     ;; NB: joda-time is pulled in by clj-time
     ;; NB: commons-logging is pulled in manually
     ;; NB: commons-codec is pulled in manually
     ;; NB: com.fasterxml.jackson.core/jackson-databind is pulled in manually
-    [amazonica "0.3.128" :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind]]
+    [amazonica "0.3.130" :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind]]
     ;; Data binding and tree for XML https://github.com/FasterXML/jackson-databind
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [com.fasterxml.jackson.core/jackson-databind "2.9.6"]
@@ -100,13 +100,13 @@
         ;; NB: clj-time is pulled in manually
         ;; NB: joda-time is pulled in by clj-time
         ;; NB: commons-codec pulled in manually
-        [midje "1.9.2-alpha3" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.2" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.6"]
+        [jonase/eastwood "0.2.9"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]
@@ -129,7 +129,7 @@
         ;; Dead code finder https://github.com/venantius/yagni
         [venantius/yagni "0.1.4" :exclusions [org.clojure/clojure]]
         ;; Autotest https://github.com/jakemcc/lein-test-refresh
-        [com.jakemccrary/lein-test-refresh "0.22.0"]
+        [com.jakemccrary/lein-test-refresh "0.23.0"]
       ]  
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.12-alpha3"
+(defproject open-company/lib "0.16.12"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -27,6 +27,7 @@
           :email lib-schema/NonBlankStr
           :auth-source (schema/pred #(auth-sources (keyword %)))
           (schema/optional-key :slack-id) schema/Str
+          (schema/optional-key :slack-display-name) schema/Str
           (schema/optional-key :slack-token) schema/Str
           (schema/optional-key :slack-bots) SlackBots
           :refresh-url lib-schema/NonBlankStr

--- a/src/oc/lib/schema.clj
+++ b/src/oc/lib/schema.clj
@@ -113,4 +113,4 @@
   {(schema/optional-key :slack-users) {schema/Keyword {:slack-org-id NonBlankStr
                                                        :id NonBlankStr
                                                        :token NonBlankStr
-                                                       (schema/optional-key :display_name) NonBlankStr}}})
+                                                       (schema/optional-key :display-name) NonBlankStr}}})

--- a/src/oc/lib/schema.clj
+++ b/src/oc/lib/schema.clj
@@ -113,4 +113,5 @@
   {(schema/optional-key :slack-users) {schema/Keyword {:slack-org-id NonBlankStr
                                                        :id NonBlankStr
                                                        :token NonBlankStr
-                                                       (schema/optional-key :display-name) NonBlankStr}}})
+                                                       (schema/optional-key :display-name) NonBlankStr
+                                                       schema/Keyword schema/Any}}}) ; and whatever else is in here

--- a/src/oc/lib/schema.clj
+++ b/src/oc/lib/schema.clj
@@ -112,4 +112,5 @@
   "`:slack-users` map with entries for each Slack team, keyed by Slack team ID, e.g. `:T1N0ASD`"
   {(schema/optional-key :slack-users) {schema/Keyword {:slack-org-id NonBlankStr
                                                        :id NonBlankStr
-                                                       :token NonBlankStr}}})
+                                                       :token NonBlankStr
+                                                       (schema/optional-key :display_name) NonBlankStr}}})


### PR DESCRIPTION
Supports: https://github.com/open-company/open-company-auth/pull/50

NB: After finishing the review of the auth PR, you need to update the version here to `0.16.12` and do a `lein deploy release`, then update the Auth, Storage and Interaction branches to use `0.16.12` and deploy all 3 to beta at the same time.

NB: If this goes out BEFORE https://github.com/open-company/open-company-lib/pull/33 (which is `0.16.11` then you need to add a note to https://github.com/open-company/open-company-lib/pull/33 that it needs to merge this and go to version `0.16.13` for the Google work.

If this goes out AFTER https://github.com/open-company/open-company-lib/pull/33 then you only need to ensure that's been merged in cleanly into this.