### PR TITLE
Add `remove-index` to migration helpers.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.14-alpha1"
+(defproject open-company/lib "0.16.14"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.13"
+(defproject open-company/lib "0.16.14-alpha1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -46,10 +46,10 @@
     [commons-codec "1.11"]
     ;; WebSocket server https://github.com/ptaoussanis/sente
     ;; NB: timbre is pulled in manually
-    [com.taoensso/sente "1.13.0" :exclusions [com.taoensso/timbre com.taoensso/encore]]
+    [com.taoensso/sente "1.13.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
-    [com.taoensso/encore "2.96.0"]
+    [com.taoensso/encore "2.97.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; NB: commons-codec pulled in manually
     [raven-clj "1.6.0-alpha" :exclusions [commons-codec]]
@@ -60,7 +60,7 @@
     ;; NB: commons-logging is pulled in manually
     ;; NB: commons-codec is pulled in manually
     ;; NB: com.fasterxml.jackson.core/jackson-databind is pulled in manually
-    [amazonica "0.3.130" :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind]]
+    [amazonica "0.3.132" :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind]]
     ;; Data binding and tree for XML https://github.com/FasterXML/jackson-databind
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [com.fasterxml.jackson.core/jackson-databind "2.9.6"]
@@ -100,7 +100,7 @@
         ;; NB: clj-time is pulled in manually
         ;; NB: joda-time is pulled in by clj-time
         ;; NB: commons-codec pulled in manually
-        [midje "1.9.2" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.3-alpha1" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje

--- a/src/oc/lib/db/migrations.clj
+++ b/src/oc/lib/db/migrations.clj
@@ -117,6 +117,14 @@
       (r/run conn))
     (wait-for-index conn table-name index-name))))
 
+(defn remove-index
+  "Remove a RethinkDB table index for the specified field if it exists."
+  [conn table-name index-name]
+  (when (some #(= index-name %) (index-list conn table-name))
+    (-> (r/table table-name)
+      (r/index-drop index-name)
+      (r/run conn))))
+
 (defn create-table
   "Create a RethinkDB table with the specified primary key if it doesn't exist."
   [conn db-name table-name primary-key]
@@ -211,7 +219,13 @@
     (m/table-list c))
 
   (with-open [c (apply r/connect conn)]
-    (m/create-table c "foo" "bar"))
+    (m/create-table c "open_company_storage_dev" "foo" "bar"))
+
+  (with-open [c (apply r/connect conn)]
+    (m/create-index c "foo" "blat"))
+
+  (with-open [c (apply r/connect conn)]
+    (m/remove-index c "foo" "blat"))
 
   (with-open [c (apply r/connect conn)]
     (m/delete-table c "foo"))


### PR DESCRIPTION
Adds a remove index option to support the revised NUX work.

To test:

- [x] Review the code
- [x] Follow the steps in `oc.lib.db.migrations` `comments` block at the bottom to create a temp. table `foo`, add an index and remove it. All good?
- [x] Drop the alpha from the version
- [x] Commit
- [x] Release it to clojars (`lein deploy release`)
- [ ] Merge and remove branch
- [ ] Make lemonade out of lemons