### PR TITLE
Fix xss strip

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.17alpha"
+(defproject open-company/lib "0.16.17"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.16"
+(defproject open-company/lib "0.16.17alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.17"
+(defproject open-company/lib "0.16.18"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -14,14 +14,14 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-alpha8" :scope "provided"]
+    [org.clojure/clojure "1.10.0-RC1" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.4.474"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha5"]
     ;; Clojure reader https://github.com/clojure/tools.reader
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
-    [org.clojure/tools.reader "1.3.0"]
+    [org.clojure/tools.reader "1.3.1"]
     ;; Tools for writing macros https://github.com/clojure/tools.macro
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [org.clojure/tools.macro "0.1.5"]
@@ -49,10 +49,10 @@
     [com.taoensso/sente "1.13.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
-    [com.taoensso/encore "2.99.0"]
+    [com.taoensso/encore "2.100.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; NB: commons-codec pulled in manually
-    [raven-clj "1.6.0-alpha" :exclusions [commons-codec]]
+    [raven-clj "1.6.0-alpha2" :exclusions [commons-codec]]
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
     [liberator "0.15.2"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
@@ -71,7 +71,7 @@
     ;; JSON encoding / decoding https://github.com/dakrone/cheshire
     [cheshire "5.8.1"] 
     ;; Date and time lib https://github.com/clj-time/clj-time
-    [clj-time "0.14.4"]
+    [clj-time "0.15.0"]
     ;; A clj-time inspired date library for clojurescript. https://github.com/andrewmcveigh/cljs-time
     [com.andrewmcveigh/cljs-time "0.5.2"]
     ;; AWS SQS consumer https://github.com/TheClimateCorporation/squeedo
@@ -100,13 +100,13 @@
         ;; NB: clj-time is pulled in manually
         ;; NB: joda-time is pulled in by clj-time
         ;; NB: commons-codec pulled in manually
-        [midje "1.9.3-alpha1" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.4" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.9"]
+        [jonase/eastwood "0.3.1"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]

--- a/src/oc/lib/text.clj
+++ b/src/oc/lib/text.clj
@@ -41,4 +41,4 @@
    Current xss tags are script, style, and input.
   "
   [data]
-  (when data (s/replace data #"<\/?([script|style|input]{1})(\s?[^<>]*)>" "")))
+  (when data (s/replace data #"(?i)<\/?((script|style|input){1})(\s?[^<>]*)>" "")))

--- a/src/oc/lib/text.clj
+++ b/src/oc/lib/text.clj
@@ -41,4 +41,4 @@
    Current xss tags are script, style, and input.
   "
   [data]
-  (when data (s/replace data #"<\/?([script|style|input])([^<>]*)>" "")))
+  (when data (s/replace data #"<\/?([script|style|input]{1})(\s?[^<>]*)>" "")))

--- a/test/oc/unit/text.clj
+++ b/test/oc/unit/text.clj
@@ -1,6 +1,6 @@
 (ns oc.unit.text
   (:require [midje.sweet :refer :all]
-            [oc.lib.text :refer (attribution)]))
+            [oc.lib.text :refer (attribution strip-xss-tags)]))
 
 (def item "foo")
 
@@ -19,3 +19,60 @@
   (attribution 4 10 item authors) => "10 foos by Sean, Nathan, Stuart, Iacopo and others"
   (attribution 5 10 item authors) => "10 foos by Sean, Nathan, Stuart, Iacopo and Ryan"
   (attribution 1 10 item authors) => "10 foos by Sean and others")
+
+(def pr-test-case "<script and something here>Hello</script><style>Style</style><input and=\"soon\"><span but-this=\"\">Will be in</span>")
+
+(def br-tag-1 "<br/>")
+(def br-tag-2 "<br/>")
+(def anchor-tag "<a href=\"http://combat.org/\">world</a>")
+(def span-tag "<span foo=\"bar\">in a span</span")
+(def script-tag "<script>alert('gotcha!')</script>")
+(def input-tag-1 "<input name='gotcha' type='email'/>")
+(def input-tag-2 "<input name='gotcha' type='email'>output</input>")
+(def style-tag "<style>I got it.</style>")
+
+(def p-with-anchor (str "<p>Hello " anchor-tag "</p>"))
+(def div-with-anchor (str "<div>Hello " anchor-tag "</div>"))
+(def p-with-span (str "<p>Hello " span-tag "</p>"))
+(def div-with-span (str "<div>Hello " span-tag "</div>"))
+
+(facts "about stripping tags"
+  
+  (tabular
+    (fact "no tags do nothing"
+      (strip-xss-tags ?string) => ?result)
+    ?string                   ?result
+    ""                        ""
+    "Hello world"             "Hello world"
+    "Hello\nworld"            "Hello\nworld")
+  
+  (tabular
+    (fact "basic formatting tags are left alone"
+      (strip-xss-tags ?string) => ?result)
+    ?string                   ?result
+    br-tag-1                  br-tag-1
+    br-tag-2                  br-tag-2
+    anchor-tag                anchor-tag
+    span-tag                  span-tag
+    "<p/>"                    "<p/>"
+    "<p></p>"                 "<p></p>"
+    "<p>Hello world</p>"      "<p>Hello world</p>"
+    p-with-anchor             p-with-anchor
+    p-with-span               p-with-span
+    "<div/>"                  "<div/>"
+    "<div></div>"             "<div></div>"
+    "<div>Hello world</div>"  "<div>Hello world</div>"
+    div-with-anchor           div-with-anchor
+    div-with-span             div-with-span)
+
+  (tabular
+    (fact "xss vulnerable tags are stripped"
+      (strip-xss-tags ?string) => ?result)
+    ?string                   ?result
+    script-tag                "alert('gotcha!')"
+    input-tag-1               ""
+    input-tag-2               "output"
+    style-tag                 "I got it.")
+  
+  (fact "PR test case passes"
+    (strip-xss-tags pr-test-case) => "HelloStyleWill be in"))

--- a/test/oc/unit/text.clj
+++ b/test/oc/unit/text.clj
@@ -21,6 +21,7 @@
   (attribution 1 10 item authors) => "10 foos by Sean and others")
 
 (def pr-test-case "<script and something here>Hello</script><style>Style</style><input and=\"soon\"><span but-this=\"\">Will be in</span>")
+(def i-test-case "<script and something here>Hello</script><STYLE>Style</STYLE><input and=\"soon\"><span but-this=\"\">Will be in</span>")
 
 (def br-tag-1 "<br/>")
 (def br-tag-2 "<br/>")
@@ -75,4 +76,7 @@
     style-tag                 "I got it.")
   
   (fact "PR test case passes"
-    (strip-xss-tags pr-test-case) => "HelloStyleWill be in"))
+    (strip-xss-tags pr-test-case) => "HelloStyle<span but-this=\"\">Will be in</span>")
+
+  (fact "Case insensitive tests"
+    (strip-xss-tags i-test-case) => "HelloStyle<span but-this=\"\">Will be in</span>"))

--- a/test/oc/unit/text.clj
+++ b/test/oc/unit/text.clj
@@ -20,22 +20,31 @@
   (attribution 5 10 item authors) => "10 foos by Sean, Nathan, Stuart, Iacopo and Ryan"
   (attribution 1 10 item authors) => "10 foos by Sean and others")
 
-(def pr-test-case "<script and something here>Hello</script><style>Style</style><input and=\"soon\"><span but-this=\"\">Will be in</span>")
-(def i-test-case "<script and something here>Hello</script><STYLE>Style</STYLE><input and=\"soon\"><span but-this=\"\">Will be in</span>")
+(def pr-i-test-case "<ScRiPt and something here>hello</script> <StYlE>style</STYLE> <iNpUt and=\"soon\"><sPaN but-this=\"\">will be in</span>")
+(def pr-test-case (clojure.string/lower-case pr-i-test-case))
 
 (def br-tag-1 "<br/>")
 (def br-tag-2 "<br/>")
 (def anchor-tag "<a href=\"http://combat.org/\">world</a>")
 (def span-tag "<span foo=\"bar\">in a span</span")
+
 (def script-tag "<script>alert('gotcha!')</script>")
 (def input-tag-1 "<input name='gotcha' type='email'/>")
 (def input-tag-2 "<input name='gotcha' type='email'>output</input>")
 (def style-tag "<style>I got it.</style>")
 
 (def p-with-anchor (str "<p>Hello " anchor-tag "</p>"))
-(def div-with-anchor (str "<div>Hello " anchor-tag "</div>"))
 (def p-with-span (str "<p>Hello " span-tag "</p>"))
+(def div-with-anchor (str "<div>Hello " anchor-tag "</div>"))
 (def div-with-span (str "<div>Hello " span-tag "</div>"))
+
+(def p-with-script (str "<p>Hello " script-tag "</p>"))
+(def p-with-input (str "<p>Hello " input-tag-1 "</p>"))
+(def p-with-style (str "<p>Hello " style-tag "</p>"))
+(def div-with-script (str "<div>Hello " script-tag "</div>"))
+(def div-with-input (str "<div>Hello " input-tag-1 "</div>"))
+(def div-with-style (str "<div>Hello " style-tag "</div>"))
+
 
 (facts "about stripping tags"
   
@@ -73,10 +82,14 @@
     script-tag                "alert('gotcha!')"
     input-tag-1               ""
     input-tag-2               "output"
-    style-tag                 "I got it.")
+    style-tag                 "I got it."
+    p-with-script             "<p>Hello alert('gotcha!')</p>"
+    p-with-input              "<p>Hello </p>"
+    p-with-style              "<p>Hello I got it.</p>"
+    div-with-script           "<div>Hello alert('gotcha!')</div>"
+    div-with-input            "<div>Hello </div>"
+    div-with-style            "<div>Hello I got it.</div>")
   
   (fact "PR test case passes"
-    (strip-xss-tags pr-test-case) => "HelloStyle<span but-this=\"\">Will be in</span>")
-
-  (fact "Case insensitive tests"
-    (strip-xss-tags i-test-case) => "HelloStyle<span but-this=\"\">Will be in</span>"))
+    (strip-xss-tags pr-test-case) => "hello style <span but-this=\"\">will be in</span>"
+    (strip-xss-tags pr-i-test-case) => "hello style <sPaN but-this=\"\">will be in</span>"))


### PR DESCRIPTION
We had a bug in the xss strip function that was stripping out all the HTML markup, not only script, style and input elements.
```
dev=> (str/strip-xss-tags "<script and something here>Hello</script><style>Style</style><input and=\"soon\"><span but-this=\"\">Will be in</span>")
"HelloStyleWill be in"
```

This should fix that.
Since i changed only this line, the rest of the PRs are only to upgrade lib it should be enough to test the function directly in repl and make sure it removes only the needed tags.
Test the function with tags like:
- `a`, `br`, `span`, `div`, `script`, `style` and `input` and any other you can think of (mostly test weird syntax situations
- test opening tags (like `<style>`)
- test auto closing tags (like `<input />`)
- test closing tags (like `</ style>`)
- test them:
- without attributes
- with multiple spaces inside the tag opening and closing tag
- withwith a single attribute name (like `disabled`)
- with an attribute with value
- with mixed attributes with and without value
- test self closing tags (like `<input />`)

Related PRs:
- storage: https://github.com/open-company/open-company-storage/pull/163
- auth: https://github.com/open-company/open-company-auth/pull/64
- interaction: https://github.com/open-company/open-company-interaction/pull/25