### PR TITLE
Pass in text with attachments

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.23alpha"
+(defproject open-company/lib "0.16.24alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -57,13 +57,15 @@
 
 (defn post-attachments
   "Post attachments as the bot."
-  [bot-token channel attachments]
-  {:pre [(sequential? attachments)
-         (every? map? attachments)]}
-  (slack-api :chat.postMessage {:token bot-token
-                                :text (with-marker "")
-                                :attachments (json/encode attachments)
-                                :channel channel}))
+  ([bot-token channel attachments]
+     (post-attachments bot-token channel attachments ""))
+  ([bot-token channel attachments text]
+     {:pre [(sequential? attachments)
+            (every? map? attachments)]}
+     (slack-api :chat.postMessage {:token bot-token
+                                   :text (with-marker text)
+                                   :attachments (json/encode attachments)
+                                   :channel channel})))
 
 (defn unfurl-post-url
   "Add data to the url when a Carrot url is posted in slack."


### PR DESCRIPTION
Before this change we were not able to send message text along with attachments.  This change allows for that to happen.

