### PR TITLE
Fix slugify issue when slug is sanitized to nothing. Test for the same.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.24alpha"
+(defproject open-company/lib "0.16.25-alpha1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -179,7 +179,10 @@
 
   :eastwood {
     ;; Disable some linters that are enabled by default
-    :exclude-linters [:constant-test :wrong-arity]
+    ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond` 
+    ;; wrong-arity - unfortunate, but it's failing on 3/arity of sqs/send-message
+    ;; implicit-dependencies - uhh, just seems dumb
+    :exclude-linters [:constant-test :wrong-arity :implicit-dependencies]
     ;; Enable some linters that are disabled by default
     :add-linters [:unused-namespaces :unused-private-vars]
     ;; Custom Eastwood config

--- a/project.clj
+++ b/project.clj
@@ -14,14 +14,14 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-RC1" :scope "provided"]
+    [org.clojure/clojure "1.10.0-RC2" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
-    [org.clojure/core.async "0.4.474"]
+    [org.clojure/core.async "0.4.490"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.match "0.3.0-alpha5"]
     ;; Clojure reader https://github.com/clojure/tools.reader
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
-    [org.clojure/tools.reader "1.3.1"]
+    [org.clojure/tools.reader "1.3.2"]
     ;; Tools for writing macros https://github.com/clojure/tools.macro
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [org.clojure/tools.macro "0.1.5"]
@@ -49,7 +49,7 @@
     [com.taoensso/sente "1.13.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
-    [com.taoensso/encore "2.100.0"]
+    [com.taoensso/encore "2.102.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; NB: commons-codec pulled in manually
     [raven-clj "1.6.0-alpha2" :exclusions [commons-codec]]
@@ -60,7 +60,7 @@
     ;; NB: commons-logging is pulled in manually
     ;; NB: commons-codec is pulled in manually
     ;; NB: com.fasterxml.jackson.core/jackson-databind is pulled in manually
-    [amazonica "0.3.132" :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind]]
+    [amazonica "0.3.134" :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind]]
     ;; Data binding and tree for XML https://github.com/FasterXML/jackson-databind
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [com.fasterxml.jackson.core/jackson-databind "2.9.7"]
@@ -71,7 +71,7 @@
     ;; JSON encoding / decoding https://github.com/dakrone/cheshire
     [cheshire "5.8.1"] 
     ;; Date and time lib https://github.com/clj-time/clj-time
-    [clj-time "0.15.0"]
+    [clj-time "0.15.1"]
     ;; A clj-time inspired date library for clojurescript. https://github.com/andrewmcveigh/cljs-time
     [com.andrewmcveigh/cljs-time "0.5.2"]
     ;; AWS SQS consumer https://github.com/TheClimateCorporation/squeedo
@@ -106,7 +106,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.3.1"]
+        [jonase/eastwood "0.3.3"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.25-alpha1"
+(defproject open-company/lib "0.16.25"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/slugify.clj
+++ b/src/oc/lib/slugify.clj
@@ -36,16 +36,18 @@
 (defn slugify
   ([resource-name] (slugify resource-name max-slug-length))
   ([resource-name max-length]
-    (-> resource-name
-      s/trim
-      replace-whitespace
-      normalize-characters
-      replace-punctuation
-      remove-non-alpha-numeric
-      s/lower-case
-      normalize-dashes
-      (truncate max-length)
-      normalize-dashes)))
+    (let [slug (-> resource-name
+                  s/trim
+                  replace-whitespace
+                  normalize-characters
+                  replace-punctuation
+                  remove-non-alpha-numeric
+                  s/lower-case
+                  normalize-dashes
+                  (truncate max-length)
+                  normalize-dashes)]
+      ;; if the slug was sanitized to nothing, use a UUID
+      (if (s/blank? slug) (oc.lib.db.common/unique-id) slug))))
 
 (defn valid-slug?
   "Return `true` if the specified slug is potentially a valid slug (follows the rules), otherwise return `false`."

--- a/test/oc/unit/slugify.clj
+++ b/test/oc/unit/slugify.clj
@@ -71,6 +71,9 @@
     "γλώσσαthis-μουέδωσανis-ελληνικήalso-მივჰხვდეaმასჩემსაالزجاجوهذالايؤلمني.slug मैकाँचखासकताฉันกินกระจกได้לאמזיק"
     "æ-ǽ-ǣ-this-♜-♛-☃-✄-✈-is-→-☞-➩-⇏-⇉-also-•-✪-▼-❊-✔-a-∑-∏-∛-≃-≈-⅋-⋶-slug")
 
+  (fact "a slug with no characters left after sanitization is relplaced with a UUID"
+    (oc.lib.schema/unique-id? (slugify "Ημερολόγιο")) => true)
+
   (fact "slugs that are too long are truncated"
     (let [long-slug (apply str (range 0 500))]
       ; default max


### PR DESCRIPTION
[Trello](https://trello.com/c/tkAqzSdx)

User used `Ημερολόγιο` as section name which slugified to nothing and broke the world.

Requires: https://github.com/open-company/open-company-storage/pull/175

To test:

- Run the storage branch mentioned above
- Create a new org named `Ημερολόγιο`
- Create a new section in the org named `Ημερολόγιο`
- [x] Nothing broke?
- Update the release version to drop the alpha in both lib and storage
- Release the lib to clojars
- Merge
- Deploy
