### PR TITLE
Auth lib

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.25.1"
+(defproject open-company/lib "0.16.27alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/auth.clj
+++ b/src/oc/lib/auth.clj
@@ -1,0 +1,47 @@
+(ns oc.lib.auth
+  "Uses a magic token to perform requests to the auth service like
+   getting a valid JWT or the complete user data."
+  (:require [cheshire.core :as json]
+            [org.httpkit.client :as http]
+            [clojure.walk :refer (keywordize-keys)]
+            [oc.lib.jwt :as jwt]))
+
+(defn- user-data [user-map]
+  (let [initial-map {:user user-map}
+        has-user-id (contains? user-map :user-id)
+        with-user-id (merge initial-map
+                       (when has-user-id
+                        {:user-id (:user-id user-map)}))
+        has-slack-user-id (contains? user-map :slack-user-id)
+        with-slack-user (merge with-user-id
+                         (when has-slack-user-id
+                           {:slack-user-id (:slack-user-id user-map)
+                            :slack-team-id (:slack-team-id user-map)}))]
+    with-slack-user))
+
+(defn- magic-token
+  [user-map passphrase service-name]
+  (jwt/generate (merge (user-data user-map)
+                 {:super-user true
+                  :name service-name
+                  :auth-source :services})
+    passphrase))
+
+(defn get-options
+  [token]
+  {:headers {"Content-Type" "application/vnd.open-company.auth.v1+json"
+             "Authorization" (str "Bearer " token)}})
+
+(defn user-token [user auth-server-url passphrase service-name]
+  (let [token-request
+        @(http/get (str auth-server-url "/users/refresh/")
+                   (get-options (magic-token user passphrase service-name)))]
+    (when (= 201 (:status token-request))
+      (:body token-request))))
+
+(defn user-data [user auth-server-url passphrase]
+  (let [user-request
+        @(http/get (str auth-server-url "/users/" (:user-id user))
+                   (get-options (magic-token user passphrase)))]
+    (when (= 200 (:status user-request))
+      (dissoc (keywordize-keys (json/parse-string (:body user-request))) :links))))

--- a/src/oc/lib/auth.clj
+++ b/src/oc/lib/auth.clj
@@ -6,7 +6,7 @@
             [clojure.walk :refer (keywordize-keys)]
             [oc.lib.jwt :as jwt]))
 
-(defn- user-data [user-map]
+(defn- user-data-map [user-map]
   (let [initial-map {:user user-map}
         has-user-id (contains? user-map :user-id)
         with-user-id (merge initial-map
@@ -21,7 +21,7 @@
 
 (defn- magic-token
   [user-map passphrase service-name]
-  (jwt/generate (merge (user-data user-map)
+  (jwt/generate (merge (user-data-map user-map)
                  {:super-user true
                   :name service-name
                   :auth-source :services})
@@ -39,9 +39,9 @@
     (when (= 201 (:status token-request))
       (:body token-request))))
 
-(defn user-data [user auth-server-url passphrase]
+(defn user-data [user auth-server-url passphrase service-name]
   (let [user-request
         @(http/get (str auth-server-url "/users/" (:user-id user))
-                   (get-options (magic-token user passphrase)))]
+                   (get-options (magic-token user passphrase service-name)))]
     (when (= 200 (:status user-request))
       (dissoc (keywordize-keys (json/parse-string (:body user-request))) :links))))


### PR DESCRIPTION
### Review after https://github.com/open-company/open-company-bot/pull/43

Move the code that request a JWT to the auth service from within a service to perform other operations.

Review with:
- [Bot PR](https://github.com/open-company/open-company-bot/pull/44)
- [Storage PR](https://github.com/open-company/open-company-storage/pull/176)
- [ Slack Router PR](https://github.com/open-company/open-company-slack-router/pull/8)

To test:
- [x] add a comment mentioning a Slack user (that has slack set as notification channel)
- [x] unfurl using these branches
- [x] add a post with a recorded video (with vimeo)
- update the lib version removing alpha here and in the 3 services using it: bot storage and slack router
- deploy the new release version
- merge
- deploy