### PR TITLE
Fix decode id-token

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.31alpha"
+(defproject open-company/lib "0.16.30.1alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/api/common.clj
+++ b/src/oc/lib/api/common.clj
@@ -192,7 +192,7 @@
      (and (:id-token (:claims (jwt/decode token)))
           (jwt/check-token token passphrase))
      {:jwtoken false
-      :user (:claims (jwt/decode token))
+      :user (:claims (jwt/decode-id-token token passphrase))
       :id-token token}
 
      (jwt/valid? token passphrase)


### PR DESCRIPTION
Use the proper function to decode the id-token to support old and new token formats.

Related PRs:
- [Storage](https://github.com/open-company/open-company-storage/pull/180)
- [Auth](https://github.com/open-company/open-company-auth/pull/72)
- [Interaction](https://github.com/open-company/open-company-interaction/pull/28)

To test:
- get an old token that has `:team-id` instead of `:teams` in it
- load a secure post url with that token
- no errors? Good
- update lib
- release lib
- merge and deploy