### PR TITLE
Return value of verify function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 Distributed under the [GNU Affero General Public License Version 3](https://www.gnu.org/licenses/agpl-3.0.en.html).
 
-Copyright © 2016-2018 OpenCompany, LLC.
+Copyright © 2016-2019 OpenCompany, LLC.
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.31"
+(defproject open-company/lib "0.16.32alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.32alpha"
+(defproject open-company/lib "0.16.32"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-RC2" :scope "provided"]
+    [org.clojure/clojure "1.10.0" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.4.490"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
@@ -112,7 +112,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.3.3"]
+        [jonase/eastwood "0.3.4"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]
@@ -133,7 +133,7 @@
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder (use carefully, false positives) https://github.com/venantius/yagni
-        [venantius/yagni "0.1.6" :exclusions [org.clojure/clojure]]
+        [venantius/yagni "0.1.7" :exclusions [org.clojure/clojure]]
         ;; Autotest https://github.com/jakemcc/lein-test-refresh
         [com.jakemccrary/lein-test-refresh "0.23.0"]
       ]  

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -155,11 +155,9 @@
   "Verify a JSON Web Token with the passphrase that was (presumably) used to generate it."
   [token passphrase]
   (try
-    (do
-      (-> token
+    (-> token
         jwt/str->jwt
         (jwt/verify passphrase))
-      true)
     (catch Exception e
       false)))
 


### PR DESCRIPTION
This change fixes and issue where an invalid token can be used successfully.

To test:
- generate a token to be used in the tests

Run the commands in the console.  In the last test you will remove one or more characters from the token.  Before this function would return true.
```
dev=> (require '[oc.lib.jwt :as jwt])
nil
dev=> (require '[oc.storage.config :as config])
nil
dev=> (jwt/check-token "<generated-token>" config/passphrase)
true
dev=> (jwt/check-token "<generated-token-minus-a-character-or-more" config/passphrase)
```

After releasing the new lib make sure to merge in the other PRs mentioned below.