### PR TITLE
Kinesis s3 sns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.33.1alpha"
+(defproject open-company/lib "0.16.33.2alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.33alpha"
+(defproject open-company/lib "0.16.33.1alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.33.2alpha"
+(defproject open-company/lib "0.16.33"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.32"
+(defproject open-company/lib "0.16.33alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/sqs.clj
+++ b/src/oc/lib/sqs.clj
@@ -67,7 +67,10 @@
                     (java.util.zip.GZIPInputStream.)
                     io/reader
                     line-seq))]
-    (read-string s3-parsed)))
+    (try
+      (read-string s3-parsed)
+      (catch Exception e
+        (json/parse-string s3-parsed true)))))
 
 (defn read-message-body
   "
@@ -78,7 +81,6 @@
                      (json/parse-string msg true)
                      (catch Exception e
                        (read-string msg)))]
-
     (cond
 
      (seq (:Records parsed-msg)) ;; from S3 to SQS

--- a/src/oc/lib/sqs.clj
+++ b/src/oc/lib/sqs.clj
@@ -83,12 +83,12 @@
 
      (seq (:Records parsed-msg)) ;; from S3 to SQS
      ;; read each record
-     (map #(read-from-s3 %) (:Records parsed-msg))
+     (map read-from-s3 (:Records parsed-msg))
 
      ;; from S3 to SNS
      (and (string? (:Message parsed-msg))
           (seq (:Records (json/parse-string (:Message parsed-msg) true))))
-     (map #(read-from-s3 %) (:Records (json/parse-string (:Message parsed-msg) true)))
+     (map read-from-s3 (:Records (json/parse-string (:Message parsed-msg) true)))
 
      :default
      [parsed-msg])))


### PR DESCRIPTION
This change supports reading from S3.  If an event message shows up in the SQS queue and it is from S3, this code will read that data.  This will allow us to write to a kinesis firehouse, send each record to s3 and then read large amounts of data from s3.