### PR TITLE
Fix lib WS 403

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.39alpha-3"
+(defproject open-company/lib "0.16.39-alpha4"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0" :scope "provided"]
+    [org.clojure/clojure "1.10.1-beta1" :scope "provided"]
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.4.490"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
@@ -32,10 +32,11 @@
     [lockedon/if-let "0.3.0"]
     ;; Component Lifecycle https://github.com/stuartsierra/component
     [com.stuartsierra/component "0.4.0"]
-    ;; ------------ NB: DO NOT UPGRADE TO 2.4.0-alpha3 ---------------------------------------------
-    ;; --- it breaks WS connections returning an net::ERR_INVALID_HTTP_RESPONSE on connect      ----
+    ;; ----------------------------------------------------------------------------------------
+    ;; --- NB: DO NOT UPGRADE TO 2.4.0-alpha3
     [http-kit "2.3.0"] ; HTTP client and server http://http-kit.org/
-    ;; ---------------------------------------------------------------------------------------------
+    ;; --- it breaks WS connections returning an net::ERR_INVALID_HTTP_RESPONSE on connect ----
+    ;; ----------------------------------------------------------------------------------------
     ;; Utility function for encoding and decoding data https://github.com/ring-clojure/ring-codec
     ;; NB: commons-codec gets picked up from amazonica
     [ring/ring-codec "1.1.1" :exclusions [commons-codec]]
@@ -49,29 +50,30 @@
     [commons-codec "1.12"]
     ;; WebSocket server https://github.com/ptaoussanis/sente
     ;; NB: timbre is pulled in manually
-    ;; --------------------- DO NOT UPDATE TO Sente 1.14.0-RC2 -----------------------------------
-    ;; ---- do not update Sente to the latest since it has breaking changes to fix CSRF which ----
-    ;; ---- we don't use since we rely on origin check, the CSRF is fake.                     ----
+    ;; ----------------------------------------------------------------------------------------
+    ;; --- NB: DO NOT UPDATE TO Sente 1.14.0-RC2
     [com.taoensso/sente "1.13.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
-    ;; -------------------------------------------------------------------------------------------
+    ;; --- it has breaking changes to fix CSRF which we don't use since we rely on origin check,
+    ;; --- our CSRF is static.
+    ;; ----------------------------------------------------------------------------------------
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
-    [com.taoensso/encore "2.106.0"]
+    [com.taoensso/encore "2.107.0"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; NB: commons-codec pulled in manually
-    [raven-clj "1.6.0-alpha2" :exclusions [commons-codec]]
+    [raven-clj "1.6.0-alpha3" :exclusions [commons-codec]]
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
-    [liberator "0.15.2"] 
+    [liberator "0.15.3"] 
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica
     ;; NB: joda-time is pulled in by clj-time
     ;; NB: commons-logging is pulled in manually
     ;; NB: commons-codec is pulled in manually
     ;; NB: com.fasterxml.jackson.core/jackson-databind is pulled in manually
     ;; NB: com.amazonaw/aws-java-sdk-dynamodb is pulled in manually to get a newer version
-    [amazonica "0.3.139"
+    [amazonica "0.3.141"
      :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind com.amazonaws/aws-java-sdk-dynamodb]]
     ;; DynamoDB SDK
-    [com.amazonaws/aws-java-sdk-dynamodb "1.11.502"]
+    [com.amazonaws/aws-java-sdk-dynamodb "1.11.524"]
     ;; Data binding and tree for XML https://github.com/FasterXML/jackson-databind
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
@@ -88,7 +90,7 @@
     ;; AWS SQS consumer https://github.com/TheClimateCorporation/squeedo
     ;; NB: com.amazonaws/jmespath-java is pulled in by Amazonica
     ;; NB: com.amazonaws/aws-java-sdk-sqs is pulled in by Amazonica
-    [com.climate/squeedo "1.0.2" :exclusions [com.amazonaws/jmespath-java com.amazonaws/aws-java-sdk-sqs]]
+    [com.climate/squeedo "1.1.1" :exclusions [com.amazonaws/jmespath-java com.amazonaws/aws-java-sdk-sqs]]
     ;; Squeedo dependency
     [org.slf4j/slf4j-nop "1.8.0-beta4"]
     ;; Data validation https://github.com/Prismatic/schema
@@ -132,7 +134,7 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.5.1" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.2" :exclusions [org.clojure/tools.cli]] 
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
@@ -144,7 +146,7 @@
         ;; Dead code finder (use carefully, false positives) https://github.com/venantius/yagni
         [venantius/yagni "0.1.7" :exclusions [org.clojure/clojure]]
         ;; Autotest https://github.com/jakemcc/lein-test-refresh
-        [com.jakemccrary/lein-test-refresh "0.23.0"]
+        [com.jakemccrary/lein-test-refresh "0.24.0"]
       ]  
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.37"
+(defproject open-company/lib "0.16.39alpha-1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -32,7 +32,10 @@
     [lockedon/if-let "0.3.0"]
     ;; Component Lifecycle https://github.com/stuartsierra/component
     [com.stuartsierra/component "0.4.0"]
-    [http-kit "2.4.0-alpha3"] ; HTTP client and server http://http-kit.org/
+    ;; ------------ NB: DO NOT UPGRADE TO 2.4.0-alpha3 ---------------------------------------------
+    ;; --- it breaks WS connections returning an net::ERR_INVALID_HTTP_RESPONSE on connect      ----
+    [http-kit "2.3.0"] ; HTTP client and server http://http-kit.org/
+    ;; ---------------------------------------------------------------------------------------------
     ;; Utility function for encoding and decoding data https://github.com/ring-clojure/ring-codec
     ;; NB: commons-codec gets picked up from amazonica
     [ring/ring-codec "1.1.1" :exclusions [commons-codec]]
@@ -46,7 +49,11 @@
     [commons-codec "1.12"]
     ;; WebSocket server https://github.com/ptaoussanis/sente
     ;; NB: timbre is pulled in manually
-    [com.taoensso/sente "1.14.0-RC2" :exclusions [com.taoensso/timbre com.taoensso/encore]]
+    ;; --------------------- DO NOT UPDATE TO Sente 1.14.0-RC2 -----------------------------------
+    ;; ---- do not update Sente to the latest since it has breaking changes to fix CSRF which ----
+    ;; ---- we don't use since we rely on origin check, the CSRF is fake.                     ----
+    [com.taoensso/sente "1.13.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
+    ;; -------------------------------------------------------------------------------------------
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
     [com.taoensso/encore "2.106.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.39-alpha4"
+(defproject open-company/lib "0.17.0"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -58,7 +58,7 @@
     ;; ----------------------------------------------------------------------------------------
     ;; Utility functions https://github.com/ptaoussanis/encore
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
-    [com.taoensso/encore "2.107.0"]
+    [com.taoensso/encore "2.108.1"]
     ;; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; NB: commons-codec pulled in manually
     [raven-clj "1.6.0-alpha3" :exclusions [commons-codec]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.39alpha-2"
+(defproject open-company/lib "0.16.39alpha-3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.16.39alpha-1"
+(defproject open-company/lib "0.16.39alpha-2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/async/watcher.clj
+++ b/src/oc/lib/async/watcher.clj
@@ -19,6 +19,14 @@
 
 (defonce watcher-go (atom nil))
 
+; ;; ----- Origin check ---
+
+(defn valid-origin-header? [ring-req]
+  (let [origin (-> ring-req :headers (get "origin"))]
+    (or (= origin "http://localhost:3559")
+        (= origin "https://staging.carrot.io")
+        (= origin "https://carrot.io"))))
+
 ; ;; ----- Storage atom and functions -----
 
 (def watchers (atom {}))

--- a/src/oc/lib/async/watcher.clj
+++ b/src/oc/lib/async/watcher.clj
@@ -19,14 +19,6 @@
 
 (defonce watcher-go (atom nil))
 
-; ;; ----- Origin check ---
-
-(defn valid-origin-header? [ring-req]
-  (let [origin (-> ring-req :headers (get "origin"))]
-    (or (= origin "http://localhost:3559")
-        (= origin "https://staging.carrot.io")
-        (= origin "https://carrot.io"))))
-
 ; ;; ----- Storage atom and functions -----
 
 (def watchers (atom {}))

--- a/src/oc/lib/middleware/wrap_ensure_origin.clj
+++ b/src/oc/lib/middleware/wrap_ensure_origin.clj
@@ -1,10 +1,17 @@
 (ns oc.lib.middleware.wrap-ensure-origin)
 
+(def origin-403-response
+ {:status 403
+  :body   "Forbidden: origin not allowed"})
+
 (defn wrap-ensure-origin
   [handler]
   (fn [request]
-    (let [origin-header (get-in request [:headers "origin"])]
-      (if (re-find #"(?i)^https:\/\/[staging\.|www\.]*carrot\.io\/?$" origin-header)
-        (handler request)
-        {:status 403
-         :body   "Forbidden: origin not allowed"}))))
+    (try
+     (let [origin-header (get-in request [:headers "origin"])]
+       (if (re-find #"(?i)^https:\/\/[staging\.|www\.]*carrot\.io\/?$" origin-header)
+         (handler request)
+         origin-403-response))
+     (catch java.lang.NullPointerException e
+       ;; Origin not provided
+       origin-403-response))))

--- a/src/oc/lib/middleware/wrap_ensure_origin.clj
+++ b/src/oc/lib/middleware/wrap_ensure_origin.clj
@@ -4,10 +4,7 @@
   [handler]
   (fn [request]
     (let [origin-header (get-in request [:headers "origin"])]
-      (if (or (= origin-header "http://localhost:3559")
-              (= origin-header "https://staging.carrot.com")
-              (= origin-header "https://www.carrot.com")
-              (= origin-header "https://carrot.com"))
+      (if (re-find #"(?i)^https:\/\/[staging\.|www\.]*carrot\.io\/?$" origin-header)
         (handler request)
         {:status 403
-         :body   "Forbidden"}))))
+         :body   "Forbidden: origin not allowed"}))))

--- a/src/oc/lib/middleware/wrap_ensure_origin.clj
+++ b/src/oc/lib/middleware/wrap_ensure_origin.clj
@@ -1,0 +1,13 @@
+(ns oc.lib.middleware.wrap-ensure-origin)
+
+(defn wrap-ensure-origin
+  [handler]
+  (fn [request]
+    (let [origin-header (get-in request [:headers "origin"])]
+      (if (or (= origin-header "http://localhost:3559")
+              (= origin-header "https://staging.carrot.com")
+              (= origin-header "https://www.carrot.com")
+              (= origin-header "https://carrot.com"))
+        (handler request)
+        {:status 403
+         :body   "Forbidden"}))))

--- a/src/oc/lib/storage.clj
+++ b/src/oc/lib/storage.clj
@@ -56,12 +56,16 @@
 
 (defun post-data-for
   "
-  Retrieve the post data with different kind of inputs.
+  Retrieve the data for the specified post from the Storage service.
+
+  Arity/5 but the 2nd argument can be either a map of the user data that will be used for
+  a JWToken, or can be a JWToken.
+
   Config:
-  - passphrase (optional needed to retrieve the JWT, not needed if JWT is passed)
-  - auth-server-url (optional needed to retrieve the JWT, not needed if JWT is passed)
-  - service-name
   - storage-server-url
+  - passphrase (not needed if JWT is passed)
+  - auth-server-url (not needed if JWT is passed)
+  - service-name (always optional)
   "
   ([config :guard #(and (map? %)
                         (contains? % :storage-server-url)


### PR DESCRIPTION
Card: https://trello.com/c/Il0A8Xbh

Needs:
- [Notify](https://github.com/open-company/open-company-notify/pull/11)
- [Interaction](https://github.com/open-company/open-company-interaction/pull/31)
- [Change](https://github.com/open-company/open-company-change/pull/15)
- [Infrastructure](https://github.com/belucid/open-company-infrastructure/pull/101)

I had to downgrade http-kit since Sente doesn't support the latest version: the latest change removed the support for the server sending messages to the client before the handshake, this feature is needed by Sente.
I also had to downgrade Sente since the latest version wasn't working w/o the CSRF token check, i tried following their docs but no luck, not sure if i am missing something or their doc is lacking, i didn't want to spend more time on this.
The new origin check is done only on staging, beta and production envs.

To test:
- test both locally and on staging
- [x] check that you can get notify, interaction and change to connect
- [x] check you receive and send messages to interaction and change
- mention yourself with another user in a comment
- [x] did you get a notification? Good
- add a section with another user
- [x] do you see the section appear in the navigation sidebar? Good (change service works)
- [x] make sure you don't get any error related to WS sockets in the js console
- now check that you get 403 if you try to connect to one of the WS services on staging (*)
- remove alpha from lib version
- release lib version w/o alpha
- update all services using it (or not)
- merge all PRs
- deploy

(*) You can check it with wscat for example, install it via npm `npm install -g wscat` and then run:
` wscat --connect "wss://staging-change.carrot.io/change-socket/user/1234-1234-1234?user-id=1234&client-id=1234"`. If you get a 403 💥 you are good to go!
If instead you get the `:chsk/handshake` message it means the origin check is not working.