### PR TITLE
Fix origin check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.0"
+(defproject open-company/lib "0.17.1-alpha3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/auth.clj
+++ b/src/oc/lib/auth.clj
@@ -30,7 +30,8 @@
 (defn get-options
   [token]
   {:headers {"Content-Type" "application/vnd.open-company.auth.v1+json"
-             "Authorization" (str "Bearer " token)}})
+             "Authorization" (str "Bearer " token)
+             "origin" "carrot.io"}})
 
 (defn user-token [user auth-server-url passphrase service-name]
   (let [token-request

--- a/src/oc/lib/change.clj
+++ b/src/oc/lib/change.clj
@@ -11,7 +11,8 @@
 
 (defn- get-post-options
   [token]
-  {:headers {"Authorization" (str "Bearer " token)}})
+  {:headers {"Authorization" (str "Bearer " token)
+             "origin" "carrot.io"}})
 
 (defn- get-data
   [request-url token]

--- a/src/oc/lib/storage.clj
+++ b/src/oc/lib/storage.clj
@@ -11,7 +11,8 @@
 
 (defn- get-post-options
   [token]
-  {:headers {"Authorization" (str "Bearer " token)}})
+  {:headers {"Authorization" (str "Bearer " token)
+             "origin" "carrot.io"}})
 
 (defn- get-data
   [request-url token]


### PR DESCRIPTION
BUG: adding the origin header check broke the internal api calls since they are done from our servers to our servers, they had no origin header set causing them to fail.
The only error i was able to see was while creating a digest, the change service api call used to retrieve the seens data were failing.

FIX: i added the `origin` header hardcoded to `carrot.io` to all the internal api calls done from `oc.lib`

### Related PRs:
- [Storage](https://github.com/open-company/open-company-storage/pull/190)
- [Bot](https://github.com/open-company/open-company-bot/pull/76)
- [Email](https://github.com/open-company/open-company-email/pull/48)
- [Slack router](https://github.com/open-company/open-company-slack-router/pull/12)

To test:
- add some posts with user A
- with user B make sure you read some posts, not all
- with user B request a digest via Slack or email
- [ ] check bot or email console for errors, no errors? Good (before the change api call were failing causing the digest task to die)
