### PR TITLE
Make author-for-user more flexible

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.0"
+(defproject open-company/lib "0.17.1-alpha2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.1-alpha2"
+(defproject open-company/lib "0.17.1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -54,13 +54,10 @@
   (let [teams (db-common/read-resources conn :teams :admins user-id)]              
     (vec (map :team-id teams))))
 
-(defun name-for
-  "Make a single `name` field from `first-name` and/or `last-name`."
-  ([user] (name-for (:first-name user) (:last-name user)))
-  ([first-name :guard s/blank? last-name :guard s/blank?] "")
-  ([first-name last-name :guard s/blank?] first-name)
-  ([first-name :guard s/blank? last-name] last-name)
-  ([first-name last-name] (str first-name " " last-name)))
+(defn name-for
+  "Fn moved to lib-schema ns. Here for backwards compatability."
+  ([user] (lib-schema/name-for user))
+  ([first last] (lib-schema/name-for first last)))
 
 (defun- bot-for
   "

--- a/src/oc/lib/jwt.clj
+++ b/src/oc/lib/jwt.clj
@@ -1,6 +1,5 @@
 (ns oc.lib.jwt
-  (:require [clojure.string :as s]
-            [if-let.core :refer (if-let* when-let*)]
+  (:require [if-let.core :refer (if-let* when-let*)]
             [defun.core :refer (defun defun-)]
             [taoensso.timbre :as timbre]
             [schema.core :as schema]


### PR DESCRIPTION
We have a common `author-for-user` fn that makes an author out of a JWT user, but we often need to do the same from a DB user. This doesn't work on the current fn because a JWT user has a `name` prop, and an author has a `name` prop, but a DB user only has `first_name` and `last_name` props. 

Elsewhere in the common code, we have a fn to derive a `name` from the other 2, but it wasn't being used in `author-for-user` making the fn only useful for transforming JWT users. This just refactors that stuff in a backwards compatible way, and updates the fn to be useful for transforming DB users into authors.

To test:
- Open a support REPL (latest mainline uses this alpha release)
- Get a JWT token parsed into a map
- Call `lib-schema/author-for-user` on the map
- [x] does your resulting author look right (name, avatar, user-id)
- Get a DB user with something like `(u/get-user-by-email stor-conn "<email>")`
- Call `lib-schema/author-for-user` on the user
- [x] does your resulting author look right (name, avatar, user-id)
- Update version and release 0.17.1 to Clojars
