### PR TITLE
Only check origin on websocket connections.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.0"
+(defproject open-company/lib "0.17.2-alpha1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -73,7 +73,7 @@
     [amazonica "0.3.141"
      :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind com.amazonaws/aws-java-sdk-dynamodb]]
     ;; DynamoDB SDK
-    [com.amazonaws/aws-java-sdk-dynamodb "1.11.524"]
+    [com.amazonaws/aws-java-sdk-dynamodb "1.11.525"]
     ;; Data binding and tree for XML https://github.com/FasterXML/jackson-databind
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [com.fasterxml.jackson.core/jackson-databind "2.9.8"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.2-alpha1"
+(defproject open-company/lib "0.17.2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/middleware/wrap_ensure_origin.clj
+++ b/src/oc/lib/middleware/wrap_ensure_origin.clj
@@ -8,10 +8,12 @@
   [handler]
   (fn [request]
     (try
-     (let [origin-header (get-in request [:headers "origin"])]
-       (if (re-find #"(?i)^https:\/\/[staging\.|www\.]*carrot\.io\/?$" origin-header)
-         (handler request)
-         origin-403-response))
+     (let [websocket? (:websocket? request)
+           origin-header (get-in request [:headers "origin"])]
+       (if (or (not websocket?) ; we only check origin on websocket requests
+                (re-find #"(?i)^https:\/\/[staging\.|www\.]*carrot\.io\/?$" origin-header))
+         (handler request) ; all is well
+         origin-403-response)) ; ye shall not pass
      (catch java.lang.NullPointerException e
-       ;; Origin not provided
+       ;; Origin not provided, also a fail
        origin-403-response))))


### PR DESCRIPTION
- [x] Review the code

To test:

- Change service is running `0.17.2-alpha1` on staging
- Pretend like your are an out-of-browser HTTP client like NodePing with `curl -i https://staging-change.carrot.io/ping`
- [x] Status OK, not denied by origin? Hot damn.
- Now pretend like you are a Websocket client w/o our orign with wscat with something like `wscat --connect "wss://staging-change.carrot.io/change-socket/user/1234-1234-1234?user-id=1234&client-id=1234"`
- [x] 403'd? You're golden.

To release:

- [x] Release jar as 0.17.2.
- Delete change service branch `0.17.2-alpha`
- Mainline/master update of oc.lib to 0.17.2 and deploy on
- [ ] Change service
- [ ] Notification service
- [ ] Interaction service
- [ ] NodePing still up on all 3? Groovy!
- [ ] WS and HTTP requests still working to all 3? Nice!
- [ ] Do some dry land ski training to prepare for next winter
