### PR TITLE
Log Slack response

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.2"
+(defproject open-company/lib "0.17.3-alpha2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.3-alpha4"
+(defproject open-company/lib "0.17.3-alpha7"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.3-alpha7.1"
+(defproject open-company/lib "0.17.3-alpha7.2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.3-alpha7.2"
+(defproject open-company/lib "0.17.3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -18,7 +18,7 @@
     ;; Async programming and communication https://github.com/clojure/core.async
     [org.clojure/core.async "0.4.490"]
     ;; Erlang-esque pattern matching https://github.com/clojure/core.match
-    [org.clojure/core.match "0.3.0-alpha5"]
+    [org.clojure/core.match "0.3.0"]
     ;; Clojure reader https://github.com/clojure/tools.reader
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [org.clojure/tools.reader "1.3.2"]
@@ -73,7 +73,7 @@
     [amazonica "0.3.141"
      :exclusions [joda-time commons-logging commons-codec com.fasterxml.jackson.core/jackson-databind com.amazonaws/aws-java-sdk-dynamodb]]
     ;; DynamoDB SDK
-    [com.amazonaws/aws-java-sdk-dynamodb "1.11.525"]
+    [com.amazonaws/aws-java-sdk-dynamodb "1.11.534"]
     ;; Data binding and tree for XML https://github.com/FasterXML/jackson-databind
     ;; NB: Not used directly, but a very common dependency, so pulled in for manual version management
     [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
@@ -104,7 +104,7 @@
     ;; HTTP client https://github.com/dakrone/clj-http
     [clj-http "3.9.1"]
     ;; String manipulation library https://github.com/funcool/cuerdas
-    [funcool/cuerdas "2.1.0"]
+    [funcool/cuerdas "2.2.0"]
   ]
 
   :profiles {
@@ -117,7 +117,7 @@
         ;; NB: clj-time is pulled in manually
         ;; NB: joda-time is pulled in by clj-time
         ;; NB: commons-codec pulled in manually
-        [midje "1.9.6" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.8" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje
@@ -146,7 +146,7 @@
         ;; Dead code finder (use carefully, false positives) https://github.com/venantius/yagni
         [venantius/yagni "0.1.7" :exclusions [org.clojure/clojure]]
         ;; Autotest https://github.com/jakemcc/lein-test-refresh
-        [com.jakemccrary/lein-test-refresh "0.24.0"]
+        [com.jakemccrary/lein-test-refresh "0.24.1"]
       ]  
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.3-alpha2"
+(defproject open-company/lib "0.17.3-alpha4"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.3-alpha7"
+(defproject open-company/lib "0.17.3-alpha7.1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -30,7 +30,12 @@
                  :body body}))
       (do 
         (timbre/trace "Slack response:" body)
-        (-> body json/decode keywordize-keys)))))
+        (try
+          (-> body json/decode keywordize-keys)
+          (catch com.fasterxml.jackson.core.JsonParseException e
+            (timbre/info "Error parsing Slack response" body)
+            (timbre/error e)
+            (throw e)))))))
 
 (defn get-team-info [token]
   (:team (slack-api :team.info {:token token})))

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -45,7 +45,7 @@
                                           :params params}))
               response-body))
           (catch com.fasterxml.jackson.core.JsonParseException e
-            (report-slack-error e)))))))
+            (report-slack-error response-body e)))))))
 
 (defn get-team-info [token]
   (:team (slack-api :team.info {:token token})))

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -45,7 +45,7 @@
                                           :params params}))
               response-body))
           (catch com.fasterxml.jackson.core.JsonParseException e
-            (report-slack-error response-body e)))))))
+            (report-slack-error body e)))))))
 
 (defn get-team-info [token]
   (:team (slack-api :team.info {:token token})))

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -38,7 +38,7 @@
         (try
           (let [response-body (-> body json/decode keywordize-keys)]
             (if-not (:ok response-body)
-              (report-slack-error body (info "Slack request was rejected"
+              (report-slack-error body (ex-info "Slack request was rejected"
                                          {:body body
                                           :status status
                                           :method method

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -18,24 +18,34 @@
   [text]
   (str marker-char text))
 
+(defn report-slack-error [body e]
+  (timbre/info "Error parsing Slack response" body)
+  (timbre/error e)
+  (throw e))
+
 (defn slack-api [method params]
   (timbre/info "Making slack request:" method)
   (let [url (str "https://slack.com/api/" (name method))
         {:keys [status headers body error] :as resp} @(http/get url {:query-params params :as :text})]
     (if error
-      (throw (ex-info "Error from Slack API"
-                {:method method
-                 :params params
-                 :status status
-                 :body body}))
+      (report-slack-error body (ex-info "Error from Slack API"
+                                {:method method
+                                 :params params
+                                 :status status
+                                 :body body}))
       (do 
         (timbre/trace "Slack response:" body)
         (try
-          (-> body json/decode keywordize-keys)
+          (let [response-body (-> body json/decode keywordize-keys)]
+            (if-not (:ok response-body)
+              (report-slack-error body (info "Slack request was rejected"
+                                         {:body body
+                                          :status status
+                                          :method method
+                                          :params params}))
+              response-body))
           (catch com.fasterxml.jackson.core.JsonParseException e
-            (timbre/info "Error parsing Slack response" body)
-            (timbre/error e)
-            (throw e)))))))
+            (report-slack-error e)))))))
 
 (defn get-team-info [token]
   (:team (slack-api :team.info {:token token})))


### PR DESCRIPTION
#### Related PR:
https://github.com/open-company/open-company-bot/pull/78

Sentry: https://sentry.io/organizations/opencompany/issues/955717539/?project=81593&referrer=slack&statsPeriod=14d

With sentries like the above we know only that we failed parsing the response from Slack but we have no clue why. With this we should get a log of the Slack response in case it failed, also the error is not suppressed but is re-thrown so we get an alert.

To test:
- deploy bot log-slack-errors to staging
- add 8 posts with some body
- ssh on staging and watch the bot logs: `sudo journalctl -u oc-bot -f`
- send yourself a Slack digest
- [x] did it fail? Good
- [x] do you see an error in the log? Good
- [x] above the error do you see `Error parsing Slack response` with the HTML page? Good
- in oc.bot.digest remove lines 140 and 149
- in uncomment lines: `140~147` (`141~148` before the step above)
- deploy bot to staging
- request a digest
- [x] did it work this time? Good
- [x] did you get the digest? Good
- [ ] update oc.lib version
- [ ] release oc.lib version
- [ ] merge both PRs
- [ ] deploy bot