### PR TITLE
Block kit accessory

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.5-alpha1"
+(defproject open-company/lib "0.17.5"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.2"
+(defproject open-company/lib "0.17.3-alpha3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/html.cljc
+++ b/src/oc/lib/html.cljc
@@ -1,0 +1,59 @@
+(ns oc.lib.html
+  "Functions related to processing text."
+  (:require [cuerdas.core :as str]
+            #?(:clj [jsoup.soup :as soup])))
+
+(defn- thumbnail-elements [body]
+  #?(:clj
+     (let [parsed-body (soup/parse body)
+           els (.select parsed-body "img:not(.emojione), iframe")]
+      {:elements els
+       :count (count els)})
+     :cljs
+     (let [$body (js/$ (str "<div>" body "</div>"))
+           els (js->clj (js/$ "img:not(.emojione), iframe" $body))]
+       {:elements els
+        :count (.-length els)})))
+
+(defn- $el [el]
+  #?(:clj
+      el
+     :cljs
+      (js/$ el)))
+
+(defn- tag-name [el]
+  #?(:clj
+      (.tagName el)
+     :cljs
+      (.-tagName el)))
+
+(defn- read-size [size]
+  #?(:clj
+     (Integer/parseInt (re-find #"\A-?\d+" size))
+     :cljs
+     size))
+
+(defn first-body-thumbnail
+  "Given an entry body get the first thumbnail available.
+  Thumbnail type: image, video or chart.
+  This rely on the similitudes between jQuery and soup parsed objects like the attr function."
+  [html-body]
+  (let [{els-count :count thumb-els :elements} (thumbnail-elements html-body)
+        found (atom nil)]
+    (dotimes [el-num els-count]
+      (let [el #?(:clj (nth thumb-els el-num) :cljs (aget thumb-els el-num))
+            $el ($el el)]
+        (when-not @found
+          (if (= (str/lower (tag-name el)) "img")
+            (let [width (read-size (.attr $el "width"))
+                  height (read-size (.attr $el "height"))]
+              (when (and (not @found)
+                         (or (<= width (* height 2))
+                             (<= height (* width 2))))
+                (reset! found
+                  {:type "image"
+                   :thumbnail (if (.attr $el "data-thumbnail")
+                                (.attr $el "data-thumbnail")
+                                (.attr $el "src"))})))
+            (reset! found {:type (.attr $el "data-media-type") :thumbnail (.attr $el "data-thumbnail")})))))
+    @found))

--- a/src/oc/lib/html.cljc
+++ b/src/oc/lib/html.cljc
@@ -1,5 +1,5 @@
 (ns oc.lib.html
-  "Functions related to processing text."
+  "Functions related to processing HTML."
   (:require [cuerdas.core :as str]
             #?(:clj [jsoup.soup :as soup])))
 
@@ -34,9 +34,11 @@
      size))
 
 (defn first-body-thumbnail
-  "Given an entry body get the first thumbnail available.
+  "
+  Given an entry body get the first thumbnail available.
   Thumbnail type: image, video or chart.
-  This rely on the similitudes between jQuery and soup parsed objects like the attr function."
+  This rely on the similitudes between jQuery and soup parsed objects like the attr function.
+  "
   [html-body]
   (let [{els-count :count thumb-els :elements} (thumbnail-elements html-body)
         found (atom nil)]


### PR DESCRIPTION
Card: https://trello.com/c/dO56dk9F

Related PRs:
- [Web](https://github.com/open-company/open-company-web/pull/842)
- [Bot](https://github.com/open-company/open-company-bot/pull/79)

To test:
- add some text posts
- add some text+image posts
- add some text+video posts
- add some text+videos+images mixed posts
- go to all posts
- [x] all showing their thumbnail right? Good
- send yourself a Slack digest
- [x] do you see the thumbnail on all posts with at least an image or a video? Good
- [x] is the thumbnail the same shown in all posts? Good
- now share a post with a thumbnail in Slack from Carrot
- [x] do you see the thumbnail in Slack? Good
- [x] you can test auto-share too if you want (it uses the same code as the above)
- [x] update oc.lib version
- [ ] change it in web and bot
- [ ] release the new oc.lib version
- [ ] merge
- [ ] deploy