### PR TITLE
Decode :redirect key from oauth state string if present

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.17"
+(defproject open-company/lib "0.17.18-alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.17.18-alpha"
+(defproject open-company/lib "0.17.18"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/oauth.cljc
+++ b/src/oc/lib/oauth.cljc
@@ -21,12 +21,17 @@
   "Given a Base64 encoded string return the decoded data."
   [state-str]
   #?(:clj
-     (let [url-decoded   (URLDecoder/decode state-str (.name StandardCharsets/UTF_8))
+     (let [decode-url    #(URLDecoder/decode % (.name StandardCharsets/UTF_8))
+           url-decoded   (decode-url state-str)
            b64-decoder   (Base64/getDecoder)
            decoded-bytes (.decode b64-decoder url-decoded)
-           decoded-str   (String. decoded-bytes)]
-       (edn/read-string decoded-str)))
+           decoded-str   (String. decoded-bytes)
+           state-map     (edn/read-string decoded-str)]
+       (cond-> state-map
+         (:redirect state-map) (update :redirect decode-url))))
   #?(:cljs
-     (-> state-str
-         js/atob
-         edn/read-string)))
+     (let [state-map (-> state-str
+                         js/atob
+                         edn/read-string)]
+       (cond-> state-map
+         (:redirect state-map) (update :redirect js/decodeURIComponent)))))


### PR DESCRIPTION
Review with:
- Auth: https://github.com/open-company/open-company-auth/pull/91
- Web: https://github.com/open-company/open-company-web/pull/1032

To test:
- Onboard user with Slack
- [x] All clear?
- Onboard user with Google
- [x] All clear?
- Invite an email user
- [x] Could they successfully onboard?
- Add the Slack bot
- [x] All clear?
- Invite a Slack user
- [x] Could they successfully onboard?
- Share a post requiring authentication, open it in incognito browser, hit the login wall
- [x] Are you able to login from here?
- Try logging in using any other method that I haven't thought of...