### PR TITLE
Fix slack channels

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.20.0-alpha"
+(defproject open-company/lib "0.20.1-alpha"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.20.1-alpha"
+(defproject open-company/lib "0.20.1-alpha1"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.20.1-alpha1"
+(defproject open-company/lib "0.20.1-alpha2"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {
@@ -60,7 +60,7 @@
     ;; NB: Not used directly, forcing this version of encore, a dependency of Timbre and Sente
     [com.taoensso/encore "3.18.0"]
     ;; Interface to Sentry error reporting https://github.com/getsentry/sentry-clj
-    [io.sentry/sentry-clj "5.0.151"]
+    [io.sentry/sentry-clj "5.0.152"]
     ;; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
     [liberator "0.15.3"]
     ;; A comprehensive Clojure client for the AWS API. https://github.com/mcohen01/amazonica

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject open-company/lib "0.20.1-alpha2"
+(defproject open-company/lib "0.20.1-alpha3"
   :description "OpenCompany Common Library"
   :url "https://github.com/open-company/open-company-lib"
   :license {

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -105,7 +105,7 @@
                 cursor (assoc :cursor (str cursor)))
          resp (slack-conversations/list (slack-connection token) opts)]
      (if (:ok resp)
-       (if-let [next-curosr (some-> resp :response_metadata :next_cursor)]
+       (if-let [next-cursor (some-> resp :response_metadata :next_cursor)]
          (concat (:channels resp) (get-channels token (assoc opts :cursor next-cursor)))
          (:channels resp))
        (report-slack-error resp (ex-info "clj-slack API error" {:method :conversations.list
@@ -269,7 +269,7 @@
     (message-webhook slack-alerts-webhook from message)))
 
 (defn alert-pagination [slack-response method & [parameters]]
-  (when (some-> hp-channels :response_metadata :next_cursor)
+  (when (some-> slack-response :response_metadata :next_cursor)
     (slack-report (format "Pagination reached for Slack %s with parameters: %s" method parameters))))
 
 (comment

--- a/src/oc/lib/slack.clj
+++ b/src/oc/lib/slack.clj
@@ -103,9 +103,10 @@
                         :limit (str limit)
                         :exclude_archived (str exclude-archived)}
                 (seq cursor) (assoc :cursor (str cursor)))
-         resp (slack-conversations/list (slack-connection token) opts)]
+         resp (slack-conversations/list (slack-connection token) opts)
+         next-cursor (some-> resp :response_metadata :next_cursor)]
      (if (:ok resp)
-       (if-let [next-cursor (some-> resp :response_metadata :next_cursor)]
+       (if (seq next-cursor)
          (->> (assoc opts :cursor next-cursor)
               (get-channels token)
               (concat (:channels resp)))


### PR DESCRIPTION
FIx pagination when the organization has more channels than our current pagination batch.

To test:
- change `oc.auth.lib.slack` line 364 to be `(slack-lib/get-channels bot-token {:limit 10})`. This will force a smaller pagination of the channels list for testing purpose
- restart your local auth server to make sure
- now sign in/up with Carrot org
- add a topic
- fill a name and description for the new section
- add a mirror channel
- do you see all the channels in the channels list? (pagination is usually 3k, but we changed it to 10 so it should be easy to check if pagination works)
- do you see all type of channels? IM, MPIM, private and public?
- select one of your IM or MPIM channels: this is to make sure the bot joins the channel, otherwise it won't be able to send messages in there when a post is published
- save the new topic
- test the share

NB: for the IM/MPIM share test you have to start the slack-router and setup the slack webhook with ngrok. Or you can use staging for it, which is already configured
